### PR TITLE
Add SysV-style init script and systemd service unit configuration

### DIFF
--- a/contrib/go-audit.init
+++ b/contrib/go-audit.init
@@ -1,0 +1,68 @@
+#!/bin/sh
+#
+# go-audit
+#
+# chkconfig:   - 15 85
+# description:  go-audit is an alternative to the auditd daemon that \
+#               ships with many distros.
+# processname: go-audit
+# config:      /etc/go-audit.yaml
+# pidfile:     /var/run/go-audit.pid
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+exec="/usr/bin/go-audit"
+prog=$(basename $exec)
+pidfile=/var/run/${prog}.pid
+
+CONFIG_FILE="/etc/go-audit.yaml"
+LOG_DIRECTORY="/var/log/go-audit"
+
+[ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+
+start() {
+    [ -f $pidfile ] && checkpid $(cat $pidfile) && echo "$prog already running" && return
+
+    echo -n $"Starting $prog: "
+    nohup $exec --config $CONFIG_FILE >>${LOG_DIRECTORY}/go-audit.out 2>>${LOG_DIRECTORY}/go-audit.err </dev/null &
+    pid=$!
+    echo $pid >$pidfile
+
+    sleep 0.1  # Sleep briefly to see if the process ends immediately
+    checkpid $(cat $pidfile)
+    status=$?
+    if [ $status -eq 0 ]; then success; else failure; fi
+    echo
+    return $status
+}
+
+stop() {
+    echo -n $"Stopping $prog: "
+    killproc -p $pidfile $prog
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $pidfile
+    return $retval
+}
+
+restart() {
+    stop
+    start
+}
+
+rh_status() {
+    status -p $pidfile $prog
+}
+
+case "$1" in
+    start|stop|restart)
+        $1
+        ;;
+    status)
+        rh_status
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart}"
+        exit 2
+esac

--- a/contrib/rh-sysv.go-audit.init
+++ b/contrib/rh-sysv.go-audit.init
@@ -12,7 +12,7 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
-exec="/usr/bin/go-audit"
+exec="/usr/local/bin/go-audit"
 prog=$(basename $exec)
 pidfile=/var/run/${prog}.pid
 


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary

This change adds a SysV-style init script and a systemd service unit configuration to manage go-audit as a service. The SysV init script is useful, in particular, on EL6-based systems (e.g. RHEL 6 and CentOS 6). The systemd service unit configuration can be used on systemd-based systems, including EL7. I have tested these on CentOS 6 and CentOS 7.