### PR TITLE
Updating the docs to indicate Golang version above 1.2.1 required

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## About
 
 go-audit is an alternative to the auditd daemon that ships with many distros.
-After having created an [auditd audisp](https://people.redhat.com/sgrubb/audit/) plugin to convert audit logs to json, 
+After having created an [auditd audisp](https://people.redhat.com/sgrubb/audit/) plugin to convert audit logs to json,
 I became interested in creating a replacement for the existing daemon.
 
 ##### Goals
@@ -21,18 +21,18 @@ I became interested in creating a replacement for the existing daemon.
 
 ##### Installation
 
-1. Install [golang](https://golang.org/doc/install)
+1. Install [golang](https://golang.org/doc/install) > 1.2.1
 2. Install [`govendor`](https://github.com/kardianos/govendor) if you haven't already
 
     ```go get -u github.com/kardianos/govendor```
-    
+
 2. Clone the repo
 
     ```
     git clone (this repo)
     cd go-audit
     ```
-    
+
 2. Build the binary
 
     ```
@@ -50,10 +50,10 @@ I became interested in creating a replacement for the existing daemon.
 - `make bench-cpulong` - run the benchmark test suite with cpu profiling and try to get some gc collection
 
 ##### Running as a service
- 
+
 Check the [contrib](contrib) folder, it contains examples for how to run `go-audit` as a proper service on your machine.
 
-##### Example Config 
+##### Example Config
 
 See [go-audit.yaml.example](go-audit.yaml.example)
 
@@ -116,6 +116,10 @@ Wikipedia has a pretty good [page](https://en.wikipedia.org/wiki/Syslog) on this
 | **local5 (21)**   | 168      | 169       | 170       | 171     | 172      | 173        | 174       | 175       |
 | **local6 (22)**   | 176      | 177       | 178       | 179     | 180      | 181        | 182       | 183       |
 | **local7 (23)**   | 184      | 185       | 186       | 187     | 188      | 189        | 190       | 191       |
+
+#### I'm getting a bunch of compilation errors related to syscall_solaris.go after running make
+
+You may be running an older version of Go (1.2.1 or below). Update to at least 1.5 to resolve these errors.
 
 ## Thanks!
 


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary

Updating documentation to reflect that compilation will fail on Go v1.2.1 (which is the default installed version by apt-get on Ubuntu 14.04). I'm not sure exactly what version of Go is required to avoid this issue, but I tested 1.5 and 1.7 and compilation was successful on both of them. The compilation errors are as follows on 1.2.1 are as follows:

```
# make
govendor sync
go build
# golang.org/x/sys/unix
../../../golang.org/x/sys/unix/syscall_solaris.go:38: clen redeclared in this block
	previous declaration at ../../../golang.org/x/sys/unix/syscall_linux.go:853
../../../golang.org/x/sys/unix/syscall_solaris.go:51: ParseDirent redeclared in this block
	previous declaration at ../../../golang.org/x/sys/unix/syscall_linux.go:866
../../../golang.org/x/sys/unix/syscall_solaris.go:77: Pipe redeclared in this block
	previous declaration at ../../../golang.org/x/sys/unix/syscall_linux_amd64.go:110
../../../golang.org/x/sys/unix/syscall_solaris.go:91: (*SockaddrInet4).sockaddr redeclared in this block
	previous declaration at ../../../golang.org/x/sys/unix/syscall_linux.go:306
../../../golang.org/x/sys/unix/syscall_solaris.go:105: (*SockaddrInet6).sockaddr redeclared in this block
	previous declaration at ../../../golang.org/x/sys/unix/syscall_linux.go:320
../../../golang.org/x/sys/unix/syscall_solaris.go:120: (*SockaddrUnix).sockaddr redeclared in this block
	previous declaration at ../../../golang.org/x/sys/unix/syscall_linux.go:335
../../../golang.org/x/sys/unix/syscall_solaris.go:146: Getsockname redeclared in this block
	previous declaration at ../../../golang.org/x/sys/unix/syscall_linux.go:561
../../../golang.org/x/sys/unix/syscall_solaris.go:155: ImplementsGetwd redeclared in this block
	previous declaration at ../../../golang.org/x/sys/unix/syscall_linux.go:179
../../../golang.org/x/sys/unix/syscall_solaris.go:159: Getwd redeclared in this block
	previous declaration at ../../../golang.org/x/sys/unix/syscall_linux.go:183
../../../golang.org/x/sys/unix/syscall_solaris.go:180: Getgroups redeclared in this block
	previous declaration at ../../../golang.org/x/sys/unix/syscall_linux.go:196
../../../golang.org/x/sys/unix/syscall_solaris.go:180: too many errors
make: *** [bin] Error 2
```

#### Related Issues

None. Happy to create one if desired.

#### Test strategy

N/A