### PR TITLE
Simple line parser program for go-audit lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ go-audit.yaml
 *.test
 *.deb
 *.out
+node_modules

--- a/contrib/line-parser/README.md
+++ b/contrib/line-parser/README.md
@@ -1,0 +1,20 @@
+## `line-parser`
+
+This program uses [`streamstash`](https://github.com/nbrownus/streamstash) to decode `go-audit` output
+
+It takes log lines from stdin and outputs the decoded json on stdout
+
+### Install
+
+Make sure you have [nodejs](https://nodejs.org/en/download/) installed, the latest LTS version is advised.
+
+Then either run `npm install` within this directory or `npm install -g https://github.com/nbrownus/streamstash#2.0`
+to install `streamstash` globally
+
+### Usage
+
+If you already have `go-audit` logging to a local file then your best bet is to run the following command
+
+```
+tail -f /path/to/file.log | ./line-parser
+```

--- a/contrib/line-parser/line-parser
+++ b/contrib/line-parser/line-parser
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+var StreamStash = require('streamstash')
+
+var logger = new StreamStash.Logger({ level: 0 }),
+    streamStash = new StreamStash({ logger: logger })
+
+process.stdin.on('end', function () {
+    process.exit(0)
+})
+
+streamStash.addInputPlugin(new StreamStash.inputs.StdInInput(
+    {
+        streamStash: streamStash,
+        EventContainer: StreamStash.EventContainer,
+        logger: logger
+    }
+))
+
+streamStash.addOutputPlugin(new StreamStash.outputs.StdOutOutput(
+    {
+        streamStash: streamStash,
+        logger: logger
+    }
+))
+
+streamStash.addFilter(function (event) {
+    StreamStash.parsers.goAuditParser(event)
+
+    delete event.data['event_source']
+    delete event.data['_type']
+
+    event.next()
+})
+
+streamStash.start()

--- a/contrib/line-parser/package.json
+++ b/contrib/line-parser/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "line-parser",
+    "description": "Parses go-audit lines from stdin, parses, and outputs on stdout",
+    "license": "MIT",
+    "version": "1.0.0",
+    "dependencies": {
+        "streamstash": "https://github.com/nbrownus/streamstash#2.0"
+    }
+}


### PR DESCRIPTION
Adds a `line-parser` script to decode `go-audit` output without running `streamstash` as a service