### PR TITLE
Enable the audit system when starting

### DIFF
--- a/go-audit.yaml.example
+++ b/go-audit.yaml.example
@@ -90,6 +90,8 @@ rules:
   - -a exit,always -F arch=b64 -S execve
   # Watch all 32 bit program executions
   - -a exit,always -F arch=b32 -S execve
+  # Enable kernel auditing (required if not done via the "audit" kernel boot parameter)
+  - -e 1
 
 # If kaudit filtering isn't powerful enough you can use the following filter mechanism
 filters:


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary

Currently, if auditing is not enabled at boot time with the `audit=1` boot parameter, go-audit does not explicitly enable it and thus once started it seems to not work. Although enabling it at boot is the most robust way to do it, it makes sense to have go-audit enable it at runtime just in case. Notably, vanilla `auditd` does this.

I'm not sure how to write a good unit test for an exec command like this so I left that part out. Advice on this would be appreciated if a unit test is necessary.