### PR TITLE
Add support for logfile rotation

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -98,26 +98,7 @@ func createOutput(config *viper.Viper) (*AuditWriter, error) {
 			return nil, err
 		}
 
-		// Re-open our log file. This is triggered by a USR1 signal and is meant to be used upon log rotation
-		sigc := make(chan os.Signal, 1)
-		signal.Notify(sigc, syscall.SIGUSR1)
-		go func() {
-			for _ = range sigc {
-				newWriter, err := createFileOutput(config)
-				if err != nil {
-					el.Fatalln("Error re-opening log file. Exiting.")
-				}
-
-				oldFile := writer.w.(*os.File)
-				writer.w = newWriter.w
-				writer.e = newWriter.e
-
-				err = oldFile.Close()
-				if err != nil {
-					el.Printf("Error closing old log file: %+v\n", err)
-				}
-			}
-		}()
+		go handleLogRotation(config, writer)
 	}
 
 	if config.GetBool("output.stdout.enabled") == true {
@@ -214,6 +195,29 @@ func createFileOutput(config *viper.Viper) (*AuditWriter, error) {
 	}
 
 	return NewAuditWriter(f, attempts), nil
+}
+
+func handleLogRotation(config *viper.Viper, writer *AuditWriter) {
+	// Re-open our log file. This is triggered by a USR1 signal and is meant to be used upon log rotation
+
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, syscall.SIGUSR1)
+
+	for _ = range sigc {
+		newWriter, err := createFileOutput(config)
+		if err != nil {
+			el.Fatalln("Error re-opening log file. Exiting.")
+		}
+
+		oldFile := writer.w.(*os.File)
+		writer.w = newWriter.w
+		writer.e = newWriter.e
+
+		err = oldFile.Close()
+		if err != nil {
+			el.Printf("Error closing old log file: %+v\n", err)
+		}
+	}
 }
 
 func createStdOutOutput(config *viper.Viper) (*AuditWriter, error) {

--- a/audit_test.go
+++ b/audit_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"syscall"
 	"testing"
+	"time"
 	"errors"
 )
 
@@ -313,6 +314,15 @@ func Test_createOutput(t *testing.T) {
 	assert.NotNil(t, w)
 	assert.IsType(t, &AuditWriter{}, w)
 	assert.IsType(t, &os.File{}, w.w)
+
+	// File rotation
+	os.Rename(path.Join(os.TempDir(), "go-audit.test.log"), path.Join(os.TempDir(), "go-audit.test.log.rotated"))
+	_, err = os.Stat(path.Join(os.TempDir(), "go-audit.test.log"))
+	assert.True(t, os.IsNotExist(err))
+	syscall.Kill(syscall.Getpid(), syscall.SIGUSR1)
+	time.Sleep(100 * time.Millisecond)
+	_, err = os.Stat(path.Join(os.TempDir(), "go-audit.test.log"))
+	assert.Nil(t, err)
 }
 
 func Benchmark_MultiPacketMessage(b *testing.B) {

--- a/contrib/logrotate.go-audit.conf
+++ b/contrib/logrotate.go-audit.conf
@@ -1,0 +1,12 @@
+/var/log/go-audit/go-audit.log {
+    compress
+    delaycompress
+    missingok
+    notifempty
+    daily
+    rotate 7
+    sharedscripts
+    postrotate
+        /usr/bin/killall -USR1 go-audit 2>/dev/null || true
+    endscript
+}

--- a/go-audit.yaml.example
+++ b/go-audit.yaml.example
@@ -64,14 +64,14 @@ output:
 
     # Path of the file to write lines to
     # The actual file will be created if it is missing but make sure the parent directory exists
-    path: /tmp/go-audit.log
+    path: /var/log/go-audit/go-audit.log
 
     # Octal file mode for the log file, make sure to always have a leading 0
     mode: 0600
 
     # User and group that should own the log file
-    user: nobody
-    group: nogroup
+    user: root
+    group: root
 
 # Configure logging, only stdout and stderr are used.
 log:


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary

Currently, when using the file output module, there is no clean way to rotate the log file it produces. This is especially important for audit log messages, which can grow very large over time.

This change will trap a USR1 signal and re-open the log file upon receipt of the signal. The intention is for this to be used along with logrotate. I've also included a sample logrotate configuration that works with it.

I've additionally changed the log file location in the example conf to /var/log/go-audit/go-audit.log, and changed the ownership to root/root (which is important since audit logs often contain sensitive information).