### PR TITLE
Fix test usage of user.Name when user has full name set

### DIFF
--- a/audit_test.go
+++ b/audit_test.go
@@ -135,8 +135,8 @@ func Test_createFileOutput(t *testing.T) {
 	g, _ := user.LookupGroupId(strconv.Itoa(gid))
 
 	// travis-ci is silly
-	if u.Name == "" {
-		u.Name = g.Name
+	if u.Username == "" {
+		u.Username = g.Name
 	}
 
 	// gid error
@@ -144,7 +144,7 @@ func Test_createFileOutput(t *testing.T) {
 	c.Set("output.file.attempts", 1)
 	c.Set("output.file.path", path.Join(os.TempDir(), "go-audit.test.log"))
 	c.Set("output.file.mode", 0644)
-	c.Set("output.file.user", u.Name)
+	c.Set("output.file.user", u.Username)
 	w, err = createFileOutput(c)
 	assert.EqualError(t, err, "Could not find gid for group . Error: group: unknown group ")
 	assert.Nil(t, w)
@@ -165,7 +165,7 @@ func Test_createFileOutput(t *testing.T) {
 	c.Set("output.file.attempts", 1)
 	c.Set("output.file.path", path.Join(os.TempDir(), "go-audit.test.log"))
 	c.Set("output.file.mode", 0644)
-	c.Set("output.file.user", u.Name)
+	c.Set("output.file.user", u.Username)
 	c.Set("output.file.group", g.Name)
 	w, err = createFileOutput(c)
 	assert.Nil(t, err)
@@ -238,8 +238,8 @@ func Test_createOutput(t *testing.T) {
 	g, _ := user.LookupGroupId(strconv.Itoa(gid))
 
 	// travis-ci is silly
-	if u.Name == "" {
-		u.Name = g.Name
+	if u.Username == "" {
+		u.Username = g.Name
 	}
 
 	l, err := net.Listen("tcp", ":0")
@@ -259,7 +259,7 @@ func Test_createOutput(t *testing.T) {
 	c.Set("output.file.attempts", 1)
 	c.Set("output.file.path", path.Join(os.TempDir(), "go-audit.test.log"))
 	c.Set("output.file.mode", 0644)
-	c.Set("output.file.user", u.Name)
+	c.Set("output.file.user", u.Username)
 	c.Set("output.file.group", g.Name)
 
 	w, err = createOutput(c)
@@ -306,7 +306,7 @@ func Test_createOutput(t *testing.T) {
 	c.Set("output.file.attempts", 1)
 	c.Set("output.file.path", path.Join(os.TempDir(), "go-audit.test.log"))
 	c.Set("output.file.mode", 0644)
-	c.Set("output.file.user", u.Name)
+	c.Set("output.file.user", u.Username)
 	c.Set("output.file.group", g.Name)
 	w, err = createOutput(c)
 	assert.Nil(t, err)


### PR DESCRIPTION
When a Linux user has a full name set, the Go user.Name field returns
the full name, rather than the username. The audit_test uses this
value for the output.file.user config, which causes the test to fail
with an unexpected "Could not find uid for user" error returned by
createFileOutput(). This patch fixes the test to use the Username field
instead of the Name field.

* [X] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
* [X] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [X] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [X] I've written tests to cover the new code and functionality included in this PR.
* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary

Fixes test on Linux with a full name configured for the current user. Test previously failed with:
```
$ go test -v
=== RUN   Test_loadConfig
--- PASS: Test_loadConfig (0.00s)
=== RUN   Test_setRules
Flushed existing audit rules
Flushed existing audit rules
Flushed existing audit rules
Added audit rule #1
Added audit rule #3
--- PASS: Test_setRules (0.00s)
=== RUN   Test_createFileOutput
--- FAIL: Test_createFileOutput (0.00s)
        Error Trace:    audit_test.go:149
	Error:		Not equal: "Could not find gid for group . Error: group: unknown group " (expected)
			        != "Could not find uid for user David Ramos. Error: user: unknown user David Ramos" (actual)
	Messages:	An error with value "Could not find gid for group . Error: group: unknown group " is expected but got "Could not find uid for user David Ramos. Error: user: unknown user David Ramos". 
		
        Error Trace:    audit_test.go:171
	Error:		Expected nil, but got: &errors.errorString{s:"Could not find uid for user David Ramos. Error: user: unknown user David Ramos"}
		
        Error Trace:    audit_test.go:172
	Error:		Expected value not to be nil.
		
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x48b212]

goroutine 7 [running]:
panic(0x7e8560, 0xc420012160)
	/usr/lib/go-1.7/src/runtime/panic.go:500 +0x1a1
testing.tRunner.func1(0xc42008e300)
	/usr/lib/go-1.7/src/testing/testing.go:579 +0x25d
panic(0x7e8560, 0xc420012160)
	/usr/lib/go-1.7/src/runtime/panic.go:458 +0x243
go-audit.Test_createFileOutput(0xc42008e300)
	/home/ramos/sdmain-6gb/src/go/src/go-audit/audit_test.go:173 +0x24a2
testing.tRunner(0xc42008e300, 0x889f00)
	/usr/lib/go-1.7/src/testing/testing.go:610 +0x81
created by testing.(*T).Run
	/usr/lib/go-1.7/src/testing/testing.go:646 +0x2ec
exit status 2
FAIL	go-audit	0.012s
```

#### Related Issues


#### Test strategy

Passed tests on Ubuntu 14.04 using a user with a full name configured
