### PR TITLE
Make event range configurable

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -336,15 +336,15 @@ func main() {
 	nlClient := NewNetlinkClient(config.GetInt("socket_buffer.receive"))
 	marshaller := NewAuditMarshaller(
 		writer,
-                uint16(config.GetInt("event.min")),
-                uint16(config.GetInt("event.max")),
+                uint16(config.GetInt("events.min")),
+                uint16(config.GetInt("events.max")),
 		config.GetBool("message_tracking.enabled"),
 		config.GetBool("message_tracking.log_out_of_order"),
 		config.GetInt("message_tracking.max_out_of_order"),
 		createFilters(config),
 	)
 
-	l.Println("Started processing events in the range [%d, %d]", config.GetInt("event.min"), config.GetInt("event.max"))
+	l.Printf("Started processing events in the range [%d, %d]\n", config.GetInt("events.min"), config.GetInt("events.max"))
 
 	//Main loop. Get data from netlink and send it to the json lib for processing
 	for {

--- a/audit.go
+++ b/audit.go
@@ -30,6 +30,8 @@ func loadConfig(configFile string) (*viper.Viper, error) {
 	config := viper.New()
 	config.SetConfigFile(configFile)
 
+        config.SetDefault("events.min", 1300)
+        config.SetDefault("events.max", 1399)
 	config.SetDefault("message_tracking.enabled", true)
 	config.SetDefault("message_tracking.log_out_of_order", false)
 	config.SetDefault("message_tracking.max_out_of_order", 500)
@@ -334,13 +336,15 @@ func main() {
 	nlClient := NewNetlinkClient(config.GetInt("socket_buffer.receive"))
 	marshaller := NewAuditMarshaller(
 		writer,
+                uint16(config.GetInt("event.min")),
+                uint16(config.GetInt("event.max")),
 		config.GetBool("message_tracking.enabled"),
 		config.GetBool("message_tracking.log_out_of_order"),
 		config.GetInt("message_tracking.max_out_of_order"),
 		createFilters(config),
 	)
 
-	l.Println("Started processing events")
+	l.Println("Started processing events in the range [%d, %d]", config.GetInt("event.min"), config.GetInt("event.max"))
 
 	//Main loop. Get data from netlink and send it to the json lib for processing
 	for {

--- a/audit_test.go
+++ b/audit_test.go
@@ -22,6 +22,8 @@ func Test_loadConfig(t *testing.T) {
 
 	// defaults
 	config, err := loadConfig(file)
+	assert.Equal(t, 1300, config.GetInt("events.min"), "events.min should default to 1300")
+	assert.Equal(t, 1399, config.GetInt("events.max"), "events.max should default to 1399")
 	assert.Equal(t, true, config.GetBool("message_tracking.enabled"), "message_tracking.enabled should default to true")
 	assert.Equal(t, false, config.GetBool("message_tracking.log_out_of_order"), "message_tracking.log_out_of_order should default to false")
 	assert.Equal(t, 500, config.GetInt("message_tracking.max_out_of_order"), "message_tracking.max_out_of_order should default to 500")
@@ -326,7 +328,7 @@ func Test_createOutput(t *testing.T) {
 }
 
 func Benchmark_MultiPacketMessage(b *testing.B) {
-	marshaller := NewAuditMarshaller(NewAuditWriter(&noopWriter{}, 1), false, false, 1, []AuditFilter{})
+	marshaller := NewAuditMarshaller(NewAuditWriter(&noopWriter{}, 1), uint16(1300), uint16(1399), false, false, 1, []AuditFilter{})
 
 	data := make([][]byte, 6)
 

--- a/go-audit.yaml.example
+++ b/go-audit.yaml.example
@@ -12,6 +12,12 @@ socket_buffer:
   # Maximum max is net.core.rmem_max (/proc/sys/net/core/rmem_max)
   receive: 16384
 
+events:
+  # Minimum event type to capture, default 1300
+  min: 1300
+  # Maximum event type to capture, default 1399
+  max: 1399
+
 # Configure message sequence tracking
 message_tracking:
   # Track messages and identify if we missed any, default true

--- a/marshaller.go
+++ b/marshaller.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	EVENT_START = 1300 // Start of the audit type ids that we care about
+	EVENT_START = 1100 // Start of the audit type ids that we care about
 	EVENT_END   = 1399 // End of the audit type ids that we care about
 	EVENT_EOE   = 1320 // End of multi packet event
 )

--- a/marshaller.go
+++ b/marshaller.go
@@ -8,8 +8,6 @@ import (
 )
 
 const (
-	EVENT_START = 1100 // Start of the audit type ids that we care about
-	EVENT_END   = 1399 // End of the audit type ids that we care about
 	EVENT_EOE   = 1320 // End of multi packet event
 )
 
@@ -19,6 +17,8 @@ type AuditMarshaller struct {
 	lastSeq       int
 	missed        map[int]bool
 	worstLag      int
+        eventMin      uint16
+        eventMax      uint16
 	trackMessages bool
 	logOutOfOrder bool
 	maxOutOfOrder int
@@ -33,11 +33,13 @@ type AuditFilter struct {
 }
 
 // Create a new marshaller
-func NewAuditMarshaller(w *AuditWriter, trackMessages, logOOO bool, maxOOO int, filters []AuditFilter) *AuditMarshaller {
+func NewAuditMarshaller(w *AuditWriter, eventMin uint16, eventMax uint16, trackMessages, logOOO bool, maxOOO int, filters []AuditFilter) *AuditMarshaller {
 	am := AuditMarshaller{
 		writer:        w,
 		msgs:          make(map[int]*AuditMessageGroup, 5), // It is not typical to have more than 2 message groups at any given time
 		missed:        make(map[int]bool, 10),
+                eventMin:      eventMin,
+                eventMax:      eventMax,
 		trackMessages: trackMessages,
 		logOutOfOrder: logOOO,
 		maxOutOfOrder: maxOOO,
@@ -73,7 +75,7 @@ func (a *AuditMarshaller) Consume(nlMsg *syscall.NetlinkMessage) {
 		a.detectMissing(aMsg.Seq)
 	}
 
-	if nlMsg.Header.Type < EVENT_START || nlMsg.Header.Type > EVENT_END {
+	if nlMsg.Header.Type < a.eventMin || nlMsg.Header.Type > a.eventMax {
 		// Drop all audit messages that aren't things we care about or end a multi packet event
 		a.flushOld()
 		return

--- a/marshaller_test.go
+++ b/marshaller_test.go
@@ -10,14 +10,12 @@ import (
 )
 
 func TestMarshallerConstants(t *testing.T) {
-	assert.Equal(t, 1100, EVENT_START)
-	assert.Equal(t, 1399, EVENT_END)
 	assert.Equal(t, 1320, EVENT_EOE)
 }
 
 func TestAuditMarshaller_Consume(t *testing.T) {
 	w := &bytes.Buffer{}
-	m := NewAuditMarshaller(NewAuditWriter(w, 1), false, false, 0, []AuditFilter{})
+	m := NewAuditMarshaller(NewAuditWriter(w, 1), uint16(1100), uint16(1399), false, false, 0, []AuditFilter{})
 
 	// Flush group on 1320
 	m.Consume(&syscall.NetlinkMessage{
@@ -125,7 +123,7 @@ func TestAuditMarshaller_completeMessage(t *testing.T) {
 	t.Skip()
 	return
 	lb, elb := hookLogger()
-	m := NewAuditMarshaller(NewAuditWriter(&FailWriter{}, 1), false, false, 0, []AuditFilter{})
+	m := NewAuditMarshaller(NewAuditWriter(&FailWriter{}, 1), uint16(1300), uint16(1399), false, false, 0, []AuditFilter{})
 
 	m.Consume(&syscall.NetlinkMessage{
 		Header: syscall.NlMsghdr{

--- a/marshaller_test.go
+++ b/marshaller_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMarshallerConstants(t *testing.T) {
-	assert.Equal(t, 1300, EVENT_START)
+	assert.Equal(t, 1100, EVENT_START)
 	assert.Equal(t, 1399, EVENT_END)
 	assert.Equal(t, 1320, EVENT_EOE)
 }
@@ -51,12 +51,12 @@ func TestAuditMarshaller_Consume(t *testing.T) {
 	)
 	assert.Equal(t, 0, len(m.msgs))
 
-	// Ignore below 1300
+	// Ignore below 1100
 	w.Reset()
 	m.Consume(&syscall.NetlinkMessage{
 		Header: syscall.NlMsghdr{
 			Len:   uint32(44),
-			Type:  uint16(1299),
+			Type:  uint16(1099),
 			Flags: uint16(0),
 			Seq:   uint32(0),
 			Pid:   uint32(0),


### PR DESCRIPTION

* [X] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
* [X] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [X] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [X] I've written tests to cover the new code and functionality included in this PR.
* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary

Currently, go-audit filters out all audit messages outside the range
[1300, 1399], which corresponds to kernel-originating events. This diff
changes that range to [1100, 1399] to include "user space trusted
application messages" (see linux/audit.h). These messages include those
sent by PAM when user sessions begin and end.

Below is an example (pretty printed) JSON produced by go-audit for such a message:
```
{
   "messages" : [
      {
         "data" : "pid=13204 uid=0 auid=1000 ses=13 msg='op=login id=1000 exe=\"/usr/sbin/sshd\" hostname=172.18.0.138 addr=172.18.0.138 terminal=/dev/pts/2 res=success'",
         "type" : 1112
      }
   ],
   "sequence" : 1016534,
   "timestamp" : "1485660821.217",
   "uid_map" : {
      "1000" : "ubuntu",
      "0" : "root"
   }
}
```

#### Related Issues

None

#### Test strategy

Existing tests seem to cover message parsing, and the new messages follow the same format as kernel-originating messages.
