### PR TITLE
Add support for graceful termination

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -342,8 +342,19 @@ func main() {
 
 	l.Println("Started processing events")
 
+	process_events := true
+
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	go func() {
+		for _ = range sigc {
+			nlClient.Close()
+			process_events = false
+		}
+	}()
+
 	//Main loop. Get data from netlink and send it to the json lib for processing
-	for {
+	for process_events {
 		msg, err := nlClient.Receive()
 		if err != nil {
 			el.Printf("Error during message receive: %+v\n", err)
@@ -356,4 +367,7 @@ func main() {
 
 		marshaller.Consume(msg)
 	}
+
+	l.Println("Exiting go-audit.")
+	os.Exit(0)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -34,7 +34,7 @@ func TestNetlinkClient_KeepConnection(t *testing.T) {
 	syscall.Close(n.fd)
 	n.KeepConnection()
 	assert.Equal(t, "", lb.String(), "Got some log lines we did not expect")
-	assert.Equal(t, "Error occurred while trying to keep the connection: bad file descriptor\n", elb.String(), "Figured we would have an error")
+	assert.Equal(t, "Error occurred while trying to set the audit PID: bad file descriptor\n", elb.String(), "Figured we would have an error")
 }
 
 func TestNetlinkClient_SendReceive(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"syscall"
 	"testing"
+	"time"
 )
 
 func TestNetlinkClient_KeepConnection(t *testing.T) {
@@ -100,6 +101,41 @@ func TestNewNetlinkClient(t *testing.T) {
 
 	assert.Equal(t, "Socket receive buffer size: ", lb.String()[:28], "Expected some nice log lines")
 	assert.Equal(t, "", elb.String(), "Did not expect any error messages")
+}
+
+func TestNetlinkClient_Close(t *testing.T) {
+	n := makeNelinkClient(t)
+
+	done := make(chan bool)
+
+	go func() {
+		msg, err := n.Receive()
+		if err != nil {
+			t.Log("Did not expect an error", err)
+			done <- false
+			return
+		}
+
+		expectedData := []byte{4, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+		binary.LittleEndian.PutUint32(expectedData[12:16], 0)
+
+		assert.Equal(t, uint16(1001), msg.Header.Type, "Header.Type mismatch")
+		assert.Equal(t, uint16(5), msg.Header.Flags, "Header.Flags mismatch")
+		assert.Equal(t, uint32(1), msg.Header.Seq, "Header.Seq mismatch")
+		assert.Equal(t, uint32(56), msg.Header.Len, "Packet size is wrong - this test is brittle though")
+		assert.EqualValues(t, msg.Data[:40], expectedData, "data was wrong")
+
+		done <- true
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	n.Close()
+	if !(<-done) {
+		t.FailNow()
+	}
+
+	// Make sure fd was closed
+	assert.Equal(t, -1, n.fd, "Netlink fd was not closed")
 }
 
 // Helper to make a client listening on a unix socket


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary

This change adds a signal handler that responds to SIGINT, SIGTERM, and SIGQUIT. It will unregister itself with kaudit and close the netlink socket (similar to what vanilla auditd would do). It will also cause the main event loop to end and gracefully exit with a 0 status code.

I've noticed that without this, the system console would get some error messages for the first audit log generated after go-audit exited. Setting the audit PID to 0 seems to be the way to effectively unregister the userspace process.