### PR TITLE
Add a simple Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.9.0-alpine3.6
+
+RUN apk --no-cache add git make
+
+WORKDIR /go/src/slackhq/go-audit
+COPY . .
+
+RUN go get -u github.com/kardianos/govendor
+RUN make
+
+FROM alpine:3.6
+COPY --from=0 /go/src/slackhq/go-audit/go-audit /usr/local/bin/
+CMD ["/usr/local/bin/go-audit"]


### PR DESCRIPTION
- Uses multi-stage builds to keep final image size small (14M)
- Uses alpine to keep image size small
- Requires a recent version of docker to build

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
 
Adds a simple Dockerfile that can be used to build a version of go-auditd.

#### Related Issues

Fixes part of #39 

#### Test strategy

1. Build the docker image with: `docker build -t go-audit .`
2. Run it with `docker run go-audit`
3. TADA!