### PR TITLE
Extendable AuditWriter Output Factory

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -4,22 +4,17 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log"
 	"log/syslog"
 	"os"
 	"os/exec"
-	"os/signal"
-	"os/user"
 	"regexp"
 	"strconv"
 	"strings"
-	"syscall"
 
+	"github.com/slackhq/go-audit/pkg/output"
+	"github.com/slackhq/go-audit/pkg/slog"
 	"github.com/spf13/viper"
 )
-
-var l = log.New(os.Stdout, "", 0)
-var el = log.New(os.Stderr, "", 0)
 
 type executor func(string, ...string) error
 
@@ -46,8 +41,7 @@ func loadConfig(configFile string) (*viper.Viper, error) {
 		return nil, err
 	}
 
-	l.SetFlags(config.GetInt("log.flags"))
-	el.SetFlags(config.GetInt("log.flags"))
+	slog.Configure(config.GetInt("log.flags"))
 
 	return config, nil
 }
@@ -58,7 +52,7 @@ func setRules(config *viper.Viper, e executor) error {
 		return fmt.Errorf("Failed to flush existing audit rules. Error: %s", err)
 	}
 
-	l.Println("Flushed existing audit rules")
+	slog.Info.Println("Flushed existing audit rules")
 
 	// Add ours in
 	if rules := config.GetStringSlice("rules"); len(rules) != 0 {
@@ -72,7 +66,7 @@ func setRules(config *viper.Viper, e executor) error {
 				return fmt.Errorf("Failed to add rule #%d. Error: %s", i+1, err)
 			}
 
-			l.Printf("Added audit rule #%d\n", i+1)
+			slog.Info.Printf("Added audit rule #%d\n", i+1)
 		}
 	} else {
 		return errors.New("No audit rules found")
@@ -81,38 +75,23 @@ func setRules(config *viper.Viper, e executor) error {
 	return nil
 }
 
-func createOutput(config *viper.Viper) (*AuditWriter, error) {
-	var writer *AuditWriter
+func createOutput(config *viper.Viper) (*output.AuditWriter, error) {
+	var writer *output.AuditWriter
 	var err error
-	i := 0
+	enabledCount := 0
 
-	if config.GetBool("output.syslog.enabled") == true {
-		i++
-		writer, err = createSyslogOutput(config)
-		if err != nil {
-			return nil, err
+	for _, auditWriterName := range output.GetAvailableAuditWriters() {
+		configName := "output." + auditWriterName + ".enabled"
+		if config.GetBool(configName) == true {
+			enabledCount++
+			writer, err = output.CreateAuditWriter(auditWriterName, config)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
-	if config.GetBool("output.file.enabled") == true {
-		i++
-		writer, err = createFileOutput(config)
-		if err != nil {
-			return nil, err
-		}
-
-		go handleLogRotation(config, writer)
-	}
-
-	if config.GetBool("output.stdout.enabled") == true {
-		i++
-		writer, err = createStdOutOutput(config)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if i > 1 {
+	if enabledCount > 1 {
 		return nil, errors.New("Only one output can be enabled at a time")
 	}
 
@@ -121,114 +100,6 @@ func createOutput(config *viper.Viper) (*AuditWriter, error) {
 	}
 
 	return writer, nil
-}
-
-func createSyslogOutput(config *viper.Viper) (*AuditWriter, error) {
-	attempts := config.GetInt("output.syslog.attempts")
-	if attempts < 1 {
-		return nil, fmt.Errorf("Output attempts for syslog must be at least 1, %v provided", attempts)
-	}
-
-	syslogWriter, err := syslog.Dial(
-		config.GetString("output.syslog.network"),
-		config.GetString("output.syslog.address"),
-		syslog.Priority(config.GetInt("output.syslog.priority")),
-		config.GetString("output.syslog.tag"),
-	)
-
-	if err != nil {
-		return nil, fmt.Errorf("Failed to open syslog writer. Error: %v", err)
-	}
-
-	return NewAuditWriter(syslogWriter, attempts), nil
-}
-
-func createFileOutput(config *viper.Viper) (*AuditWriter, error) {
-	attempts := config.GetInt("output.file.attempts")
-	if attempts < 1 {
-		return nil, fmt.Errorf("Output attempts for file must be at least 1, %v provided", attempts)
-	}
-
-	mode := os.FileMode(config.GetInt("output.file.mode"))
-	if mode < 1 {
-		return nil, errors.New("Output file mode should be greater than 0000")
-	}
-
-	f, err := os.OpenFile(
-		config.GetString("output.file.path"),
-		os.O_APPEND|os.O_CREATE|os.O_WRONLY, mode,
-	)
-
-	if err != nil {
-		return nil, fmt.Errorf("Failed to open output file. Error: %s", err)
-	}
-
-	if err := f.Chmod(mode); err != nil {
-		return nil, fmt.Errorf("Failed to set file permissions. Error: %s", err)
-	}
-
-	uname := config.GetString("output.file.user")
-	u, err := user.Lookup(uname)
-	if err != nil {
-		return nil, fmt.Errorf("Could not find uid for user %s. Error: %s", uname, err)
-	}
-
-	gname := config.GetString("output.file.group")
-	g, err := user.LookupGroup(gname)
-	if err != nil {
-		return nil, fmt.Errorf("Could not find gid for group %s. Error: %s", gname, err)
-	}
-
-	uid, err := strconv.ParseInt(u.Uid, 10, 32)
-	if err != nil {
-		return nil, fmt.Errorf("Found uid could not be parsed. Error: %s", err)
-	}
-
-	gid, err := strconv.ParseInt(g.Gid, 10, 32)
-	if err != nil {
-		return nil, fmt.Errorf("Found gid could not be parsed. Error: %s", err)
-	}
-
-	if err = f.Chown(int(uid), int(gid)); err != nil {
-		return nil, fmt.Errorf("Could not chown output file. Error: %s", err)
-	}
-
-	return NewAuditWriter(f, attempts), nil
-}
-
-func handleLogRotation(config *viper.Viper, writer *AuditWriter) {
-	// Re-open our log file. This is triggered by a USR1 signal and is meant to be used upon log rotation
-
-	sigc := make(chan os.Signal, 1)
-	signal.Notify(sigc, syscall.SIGUSR1)
-
-	for range sigc {
-		newWriter, err := createFileOutput(config)
-		if err != nil {
-			el.Fatalln("Error re-opening log file. Exiting.")
-		}
-
-		oldFile := writer.w.(*os.File)
-		writer.w = newWriter.w
-		writer.e = newWriter.e
-
-		err = oldFile.Close()
-		if err != nil {
-			el.Printf("Error closing old log file: %+v\n", err)
-		}
-	}
-}
-
-func createStdOutOutput(config *viper.Viper) (*AuditWriter, error) {
-	attempts := config.GetInt("output.stdout.attempts")
-	if attempts < 1 {
-		return nil, fmt.Errorf("Output attempts for stdout must be at least 1, %v provided", attempts)
-	}
-
-	// l logger is no longer stdout
-	l.SetOutput(os.Stderr)
-
-	return NewAuditWriter(os.Stdout, attempts), nil
 }
 
 func createFilters(config *viper.Viper) ([]AuditFilter, error) {
@@ -305,7 +176,7 @@ func createFilters(config *viper.Viper) ([]AuditFilter, error) {
 		}
 
 		filters = append(filters, af)
-		l.Printf("Ignoring syscall `%v` containing message type `%v` matching string `%s`\n", af.syscall, af.messageType, af.regex.String())
+		slog.Info.Printf("Ignoring syscall `%v` containing message type `%v` matching string `%s`\n", af.syscall, af.messageType, af.regex.String())
 	}
 
 	return filters, nil
@@ -317,34 +188,34 @@ func main() {
 	flag.Parse()
 
 	if *configFile == "" {
-		el.Println("A config file must be provided")
+		slog.Error.Println("A config file must be provided")
 		flag.Usage()
 		os.Exit(1)
 	}
 
 	config, err := loadConfig(*configFile)
 	if err != nil {
-		el.Fatal(err)
+		slog.Error.Fatal(err)
 	}
 
 	// output needs to be created before anything that write to stdout
 	writer, err := createOutput(config)
 	if err != nil {
-		el.Fatal(err)
+		slog.Error.Fatal(err)
 	}
 
 	if err := setRules(config, lExec); err != nil {
-		el.Fatal(err)
+		slog.Error.Fatal(err)
 	}
 
 	filters, err := createFilters(config)
 	if err != nil {
-		el.Fatal(err)
+		slog.Error.Fatal(err)
 	}
 
 	nlClient, err := NewNetlinkClient(config.GetInt("socket_buffer.receive"))
 	if err != nil {
-		el.Fatal(err)
+		slog.Error.Fatal(err)
 	}
 
 	marshaller := NewAuditMarshaller(
@@ -357,13 +228,13 @@ func main() {
 		filters,
 	)
 
-	l.Printf("Started processing events in the range [%d, %d]\n", config.GetInt("events.min"), config.GetInt("events.max"))
+	slog.Info.Printf("Started processing events in the range [%d, %d]\n", config.GetInt("events.min"), config.GetInt("events.max"))
 
 	//Main loop. Get data from netlink and send it to the json lib for processing
 	for {
 		msg, err := nlClient.Receive()
 		if err != nil {
-			el.Printf("Error during message receive: %+v\n", err)
+			slog.Error.Printf("Error during message receive: %+v\n", err)
 			continue
 		}
 

--- a/audit_test.go
+++ b/audit_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"io/ioutil"
-	"log/syslog"
 	"net"
 	"os"
 	"os/user"
@@ -11,8 +10,9 @@ import (
 	"strconv"
 	"syscall"
 	"testing"
-	"time"
 
+	"github.com/slackhq/go-audit/pkg/output"
+	"github.com/slackhq/go-audit/pkg/slog"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
@@ -33,8 +33,8 @@ func Test_loadConfig(t *testing.T) {
 	assert.Equal(t, "go-audit", config.GetString("output.syslog.tag"), "output.syslog.tag should default to go-audit")
 	assert.Equal(t, 3, config.GetInt("output.syslog.attempts"), "output.syslog.attempts should default to 3")
 	assert.Equal(t, 0, config.GetInt("log.flags"), "log.flags should default to 0")
-	assert.Equal(t, 0, l.Flags(), "stdout log flags was wrong")
-	assert.Equal(t, 0, el.Flags(), "stderr log flags was wrong")
+	assert.Equal(t, 0, slog.Info.Flags(), "stdout log flags was wrong")
+	assert.Equal(t, 0, slog.Error.Flags(), "stderr log flags was wrong")
 	assert.Nil(t, err)
 
 	// parse error
@@ -99,135 +99,6 @@ func Test_setRules(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func Test_createFileOutput(t *testing.T) {
-	// attempts error
-	c := viper.New()
-	c.Set("output.file.attempts", 0)
-	w, err := createFileOutput(c)
-	assert.EqualError(t, err, "Output attempts for file must be at least 1, 0 provided")
-	assert.Nil(t, w)
-
-	// failure to create/open file
-	c = viper.New()
-	c.Set("output.file.attempts", 1)
-	c.Set("output.file.path", "/do/not/exist/please")
-	c.Set("output.file.mode", 0644)
-	w, err = createFileOutput(c)
-	assert.EqualError(t, err, "Failed to open output file. Error: open /do/not/exist/please: no such file or directory")
-	assert.Nil(t, w)
-
-	// chmod error
-	c = viper.New()
-	c.Set("output.file.attempts", 1)
-	c.Set("output.file.path", path.Join(os.TempDir(), "go-audit.test.log"))
-	w, err = createFileOutput(c)
-	assert.EqualError(t, err, "Output file mode should be greater than 0000")
-	assert.Nil(t, w)
-
-	// uid error
-	c = viper.New()
-	c.Set("output.file.attempts", 1)
-	c.Set("output.file.path", path.Join(os.TempDir(), "go-audit.test.log"))
-	c.Set("output.file.mode", 0644)
-	w, err = createFileOutput(c)
-	assert.EqualError(t, err, "Could not find uid for user . Error: user: unknown user ")
-	assert.Nil(t, w)
-
-	uid := os.Getuid()
-	gid := os.Getgid()
-	u, _ := user.LookupId(strconv.Itoa(uid))
-	g, _ := user.LookupGroupId(strconv.Itoa(gid))
-
-	// travis-ci is silly
-	if u.Username == "" {
-		u.Username = g.Name
-	}
-
-	// gid error
-	c = viper.New()
-	c.Set("output.file.attempts", 1)
-	c.Set("output.file.path", path.Join(os.TempDir(), "go-audit.test.log"))
-	c.Set("output.file.mode", 0644)
-	c.Set("output.file.user", u.Username)
-	w, err = createFileOutput(c)
-	assert.EqualError(t, err, "Could not find gid for group . Error: group: unknown group ")
-	assert.Nil(t, w)
-
-	// chown error
-	c = viper.New()
-	c.Set("output.file.attempts", 1)
-	c.Set("output.file.path", path.Join(os.TempDir(), "go-audit.test.log"))
-	c.Set("output.file.mode", 0644)
-	c.Set("output.file.user", "root")
-	c.Set("output.file.group", "root")
-	w, err = createFileOutput(c)
-	assert.EqualError(t, err, "Could not chown output file. Error: chown /tmp/go-audit.test.log: operation not permitted")
-	assert.Nil(t, w)
-
-	// All good
-	c = viper.New()
-	c.Set("output.file.attempts", 1)
-	c.Set("output.file.path", path.Join(os.TempDir(), "go-audit.test.log"))
-	c.Set("output.file.mode", 0644)
-	c.Set("output.file.user", u.Username)
-	c.Set("output.file.group", g.Name)
-	w, err = createFileOutput(c)
-	assert.Nil(t, err)
-	assert.NotNil(t, w)
-	assert.IsType(t, &os.File{}, w.w)
-}
-
-func Test_createSyslogOutput(t *testing.T) {
-	// attempts error
-	c := viper.New()
-	c.Set("output.syslog.attempts", 0)
-	w, err := createSyslogOutput(c)
-	assert.EqualError(t, err, "Output attempts for syslog must be at least 1, 0 provided")
-	assert.Nil(t, w)
-
-	// dial error
-	c = viper.New()
-	c.Set("output.syslog.attempts", 1)
-	c.Set("output.syslog.priority", -1)
-	w, err = createSyslogOutput(c)
-	assert.EqualError(t, err, "Failed to open syslog writer. Error: log/syslog: invalid priority")
-	assert.Nil(t, w)
-
-	// All good
-	l, err := net.Listen("tcp", ":0")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer l.Close()
-
-	c = viper.New()
-	c.Set("output.syslog.attempts", 1)
-	c.Set("output.syslog.network", "tcp")
-	c.Set("output.syslog.address", l.Addr().String())
-	w, err = createSyslogOutput(c)
-	assert.Nil(t, err)
-	assert.NotNil(t, w)
-	assert.IsType(t, &syslog.Writer{}, w.w)
-}
-
-func Test_createStdOutOutput(t *testing.T) {
-	// attempts error
-	c := viper.New()
-	c.Set("output.stdout.attempts", 0)
-	w, err := createStdOutOutput(c)
-	assert.EqualError(t, err, "Output attempts for stdout must be at least 1, 0 provided")
-	assert.Nil(t, w)
-
-	// All good
-	c = viper.New()
-	c.Set("output.stdout.attempts", 1)
-	w, err = createStdOutOutput(c)
-	assert.Nil(t, err)
-	assert.NotNil(t, w)
-	assert.IsType(t, &os.File{}, w.w)
-}
-
 func Test_createOutput(t *testing.T) {
 	// no outputs
 	c := viper.New()
@@ -269,63 +140,6 @@ func Test_createOutput(t *testing.T) {
 	w, err = createOutput(c)
 	assert.EqualError(t, err, "Only one output can be enabled at a time")
 	assert.Nil(t, w)
-
-	// syslog error
-	c = viper.New()
-	c.Set("output.syslog.enabled", true)
-	c.Set("output.syslog.attempts", 0)
-	w, err = createOutput(c)
-	assert.EqualError(t, err, "Output attempts for syslog must be at least 1, 0 provided")
-	assert.Nil(t, w)
-
-	// file error
-	c = viper.New()
-	c.Set("output.file.enabled", true)
-	c.Set("output.file.attempts", 0)
-	w, err = createOutput(c)
-	assert.EqualError(t, err, "Output attempts for file must be at least 1, 0 provided")
-	assert.Nil(t, w)
-
-	// stdout error
-	c = viper.New()
-	c.Set("output.stdout.enabled", true)
-	c.Set("output.stdout.attempts", 0)
-	w, err = createOutput(c)
-	assert.EqualError(t, err, "Output attempts for stdout must be at least 1, 0 provided")
-	assert.Nil(t, w)
-
-	// All good syslog
-	c = viper.New()
-	c.Set("output.syslog.attempts", 1)
-	c.Set("output.syslog.network", "tcp")
-	c.Set("output.syslog.address", l.Addr().String())
-	w, err = createSyslogOutput(c)
-	assert.Nil(t, err)
-	assert.NotNil(t, w)
-	assert.IsType(t, &syslog.Writer{}, w.w)
-
-	// All good file
-	c = viper.New()
-	c.Set("output.file.enabled", true)
-	c.Set("output.file.attempts", 1)
-	c.Set("output.file.path", path.Join(os.TempDir(), "go-audit.test.log"))
-	c.Set("output.file.mode", 0644)
-	c.Set("output.file.user", u.Username)
-	c.Set("output.file.group", g.Name)
-	w, err = createOutput(c)
-	assert.Nil(t, err)
-	assert.NotNil(t, w)
-	assert.IsType(t, &AuditWriter{}, w)
-	assert.IsType(t, &os.File{}, w.w)
-
-	// File rotation
-	os.Rename(path.Join(os.TempDir(), "go-audit.test.log"), path.Join(os.TempDir(), "go-audit.test.log.rotated"))
-	_, err = os.Stat(path.Join(os.TempDir(), "go-audit.test.log"))
-	assert.True(t, os.IsNotExist(err))
-	syscall.Kill(syscall.Getpid(), syscall.SIGUSR1)
-	time.Sleep(100 * time.Millisecond)
-	_, err = os.Stat(path.Join(os.TempDir(), "go-audit.test.log"))
-	assert.Nil(t, err)
 }
 
 func Test_createFilters(t *testing.T) {
@@ -458,7 +272,7 @@ func Test_createFilters(t *testing.T) {
 }
 
 func Benchmark_MultiPacketMessage(b *testing.B) {
-	marshaller := NewAuditMarshaller(NewAuditWriter(&noopWriter{}, 1), uint16(1300), uint16(1399), false, false, 1, []AuditFilter{})
+	marshaller := NewAuditMarshaller(output.NewAuditWriter(&noopWriter{}, 1), uint16(1300), uint16(1399), false, false, 1, []AuditFilter{})
 
 	data := make([][]byte, 6)
 

--- a/client.go
+++ b/client.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"syscall"
 	"time"
-	"fmt"
+
+	"github.com/slackhq/go-audit/pkg/slog"
 )
 
 // Endianness is an alias for what we assume is the current machine endianness
@@ -63,13 +65,13 @@ func NewNetlinkClient(recvSize int) (*NetlinkClient, error) {
 	// Set the buffer size if we were asked
 	if recvSize > 0 {
 		if err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_RCVBUF, recvSize); err != nil {
-			el.Println("Failed to set receive buffer size")
+			slog.Error.Println("Failed to set receive buffer size")
 		}
 	}
 
 	// Print the current receive buffer size
 	if v, err := syscall.GetsockoptInt(n.fd, syscall.SOL_SOCKET, syscall.SO_RCVBUF); err == nil {
-		l.Println("Socket receive buffer size:", v)
+		slog.Info.Println("Socket receive buffer size:", v)
 	}
 
 	go func() {
@@ -151,6 +153,6 @@ func (n *NetlinkClient) KeepConnection() {
 
 	err := n.Send(packet, payload)
 	if err != nil {
-		el.Println("Error occurred while trying to keep the connection:", err)
+		slog.Error.Println("Error occurred while trying to keep the connection:", err)
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"bytes"
 	"encoding/binary"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"syscall"
 	"testing"
+
+	"github.com/slackhq/go-audit/pkg/slog"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNetlinkClient_KeepConnection(t *testing.T) {
@@ -146,16 +148,16 @@ func sendReceive(t *testing.T, n *NetlinkClient, packet *NetlinkPacket, payload 
 
 // Resets global loggers
 func resetLogger() {
-	l.SetOutput(os.Stdout)
-	el.SetOutput(os.Stderr)
+	slog.Info.SetOutput(os.Stdout)
+	slog.Error.SetOutput(os.Stderr)
 }
 
 // Hooks the global loggers writers so you can assert their contents
 func hookLogger() (lb *bytes.Buffer, elb *bytes.Buffer) {
 	lb = &bytes.Buffer{}
-	l.SetOutput(lb)
+	slog.Info.SetOutput(lb)
 
 	elb = &bytes.Buffer{}
-	el.SetOutput(elb)
+	slog.Error.SetOutput(elb)
 	return
 }

--- a/marshaller_test.go
+++ b/marshaller_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/slackhq/go-audit/pkg/output"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,7 +17,7 @@ func TestMarshallerConstants(t *testing.T) {
 
 func TestAuditMarshaller_Consume(t *testing.T) {
 	w := &bytes.Buffer{}
-	m := NewAuditMarshaller(NewAuditWriter(w, 1), uint16(1100), uint16(1399), false, false, 0, []AuditFilter{})
+	m := NewAuditMarshaller(output.NewAuditWriter(w, 1), uint16(1100), uint16(1399), false, false, 0, []AuditFilter{})
 
 	// Flush group on 1320
 	m.Consume(&syscall.NetlinkMessage{

--- a/pkg/output/audit_writer_factory.go
+++ b/pkg/output/audit_writer_factory.go
@@ -1,0 +1,56 @@
+package output
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/slackhq/go-audit/pkg/slog"
+	"github.com/spf13/viper"
+)
+
+type AuditWriterFactory func(conf *viper.Viper) (*AuditWriter, error)
+
+var auditWriterFactories = make(map[string]AuditWriterFactory)
+
+// register adds the audit writer type to the factory
+// this method is internal to this package and is used
+// by passing in the constructor (factory method) in
+// with a string as the key. This is done in the init
+// function of the file, thus creating self-registering
+// output audit writer factories
+func register(name string, factory AuditWriterFactory) {
+	if factory == nil {
+		slog.Error.Fatalf("Audit writer factory %s does not exist.", name)
+	}
+	_, registered := auditWriterFactories[name]
+	if registered {
+		slog.Info.Printf("Audit writer factory %s already registered. Ignoring.", name)
+		return
+	}
+
+	auditWriterFactories[name] = factory
+}
+
+// CreateAuditWriter creates an audit writer with the type specified by the name, the
+// viper config is passed down to the audit writer factory method.
+// It returns an audit writer or an error
+func CreateAuditWriter(auditWriterName string, config *viper.Viper) (*AuditWriter, error) {
+	auditWriterFactory, ok := auditWriterFactories[auditWriterName]
+	if !ok {
+		availableAuditWriters := GetAvailableAuditWriters()
+		return nil, errors.New(fmt.Sprintf("Invalid audit writer name. Must be one of: %s", strings.Join(availableAuditWriters, ", ")))
+	}
+
+	// Run the factory with the configuration.
+	return auditWriterFactory(config)
+}
+
+// GetAvailableAuditWriters returns an array of audit writer names as strings
+func GetAvailableAuditWriters() []string {
+	availableAuditWriters := make([]string, len(auditWriterFactories))
+	for k, _ := range auditWriterFactories {
+		availableAuditWriters = append(availableAuditWriters, k)
+	}
+	return availableAuditWriters
+}

--- a/pkg/output/audit_writer_factory_test.go
+++ b/pkg/output/audit_writer_factory_test.go
@@ -1,0 +1,67 @@
+package output
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+type noopWriter struct{ t *testing.T }
+
+func (t *noopWriter) Write(a []byte) (int, error) {
+	return 0, nil
+}
+
+func testFactory(conf *viper.Viper) (*AuditWriter, error) {
+	return NewAuditWriter(&noopWriter{}, 1), nil
+}
+
+func secondTestFactory(conf *viper.Viper) (*AuditWriter, error) {
+	return nil, errors.New("someerror")
+}
+
+func TestRegistrationProcess(t *testing.T) {
+	// The factory registered in this test should not show up in the avail
+	// writers prior to the call, the register is not called in init
+	before := GetAvailableAuditWriters()
+	register("test1", testFactory)
+	after := GetAvailableAuditWriters()
+
+	assert.NotContains(t, before, "test1")
+	assert.Contains(t, after, "test1")
+
+	// already registered should only show one in avail writers
+	register("test1", secondTestFactory)
+	after = GetAvailableAuditWriters()
+
+	matchedWriterCount := 0
+	for _, val := range after {
+		if val == "test1" {
+			matchedWriterCount++
+		}
+	}
+
+	assert.Equal(t, matchedWriterCount, 1)
+}
+
+func TestCreateAuditWriter(t *testing.T) {
+	config := viper.New()
+
+	// invalid
+	result, err := CreateAuditWriter("doesnotexist", config)
+	assert.NotNil(t, err)
+	assert.Nil(t, result)
+
+	register("successtest", testFactory)
+	writer, err := CreateAuditWriter("successtest", config)
+
+	assert.NotNil(t, writer)
+	assert.Nil(t, err)
+
+	register("errortest", secondTestFactory)
+	writer, err = CreateAuditWriter("errortest", config)
+	assert.Nil(t, writer)
+	assert.NotNil(t, err)
+}

--- a/pkg/output/file_writer.go
+++ b/pkg/output/file_writer.go
@@ -1,0 +1,68 @@
+package output
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"strconv"
+
+	"github.com/spf13/viper"
+)
+
+func init() {
+	register("file", newFileWriter)
+}
+
+func newFileWriter(config *viper.Viper) (*AuditWriter, error) {
+	attempts := config.GetInt("output.file.attempts")
+	if attempts < 1 {
+		return nil, fmt.Errorf("Output attempts for file must be at least 1, %v provided", attempts)
+	}
+
+	mode := os.FileMode(config.GetInt("output.file.mode"))
+	if mode < 1 {
+		return nil, errors.New("Output file mode should be greater than 0000")
+	}
+
+	f, err := os.OpenFile(
+		config.GetString("output.file.path"),
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, mode,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("Failed to open output file. Error: %s", err)
+	}
+
+	if err := f.Chmod(mode); err != nil {
+		return nil, fmt.Errorf("Failed to set file permissions. Error: %s", err)
+	}
+
+	uname := config.GetString("output.file.user")
+	u, err := user.Lookup(uname)
+	if err != nil {
+		return nil, fmt.Errorf("Could not find uid for user %s. Error: %s", uname, err)
+	}
+
+	gname := config.GetString("output.file.group")
+	g, err := user.LookupGroup(gname)
+	if err != nil {
+		return nil, fmt.Errorf("Could not find gid for group %s. Error: %s", gname, err)
+	}
+
+	uid, err := strconv.ParseInt(u.Uid, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("Found uid could not be parsed. Error: %s", err)
+	}
+
+	gid, err := strconv.ParseInt(g.Gid, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("Found gid could not be parsed. Error: %s", err)
+	}
+
+	if err = f.Chown(int(uid), int(gid)); err != nil {
+		return nil, fmt.Errorf("Could not chown output file. Error: %s", err)
+	}
+
+	return NewAuditWriter(f, attempts), nil
+}

--- a/pkg/output/file_writer_test.go
+++ b/pkg/output/file_writer_test.go
@@ -1,0 +1,113 @@
+package output
+
+import (
+	"os"
+	"os/user"
+	"path"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_newFileWriter(t *testing.T) {
+	// attempts error
+	c := viper.New()
+	c.Set("output.file.attempts", 0)
+	w, err := newFileWriter(c)
+	assert.EqualError(t, err, "Output attempts for file must be at least 1, 0 provided")
+	assert.Nil(t, w)
+
+	// failure to create/open file
+	c = viper.New()
+	c.Set("output.file.attempts", 1)
+	c.Set("output.file.path", "/do/not/exist/please")
+	c.Set("output.file.mode", 0644)
+	w, err = newFileWriter(c)
+	assert.EqualError(t, err, "Failed to open output file. Error: open /do/not/exist/please: no such file or directory")
+	assert.Nil(t, w)
+
+	// chmod error
+	c = viper.New()
+	c.Set("output.file.attempts", 1)
+	c.Set("output.file.path", path.Join(os.TempDir(), "go-audit.test.log"))
+	w, err = newFileWriter(c)
+	assert.EqualError(t, err, "Output file mode should be greater than 0000")
+	assert.Nil(t, w)
+
+	// uid error
+	c = viper.New()
+	c.Set("output.file.attempts", 1)
+	c.Set("output.file.path", path.Join(os.TempDir(), "go-audit.test.log"))
+	c.Set("output.file.mode", 0644)
+	w, err = newFileWriter(c)
+	assert.EqualError(t, err, "Could not find uid for user . Error: user: unknown user ")
+	assert.Nil(t, w)
+
+	uid := os.Getuid()
+	gid := os.Getgid()
+	u, _ := user.LookupId(strconv.Itoa(uid))
+	g, _ := user.LookupGroupId(strconv.Itoa(gid))
+
+	// travis-ci is silly
+	if u.Username == "" {
+		u.Username = g.Name
+	}
+
+	// gid error
+	c = viper.New()
+	c.Set("output.file.attempts", 1)
+	c.Set("output.file.path", path.Join(os.TempDir(), "go-audit.test.log"))
+	c.Set("output.file.mode", 0644)
+	c.Set("output.file.user", u.Username)
+	w, err = newFileWriter(c)
+	assert.EqualError(t, err, "Could not find gid for group . Error: group: unknown group ")
+	assert.Nil(t, w)
+
+	// chown error
+	c = viper.New()
+	c.Set("output.file.attempts", 1)
+	c.Set("output.file.path", path.Join(os.TempDir(), "go-audit.test.log"))
+	c.Set("output.file.mode", 0644)
+	c.Set("output.file.user", "root")
+	c.Set("output.file.group", "root")
+	w, err = newFileWriter(c)
+	assert.EqualError(t, err, "Could not chown output file. Error: chown /tmp/go-audit.test.log: operation not permitted")
+	assert.Nil(t, w)
+
+	// All good
+	c = viper.New()
+	c.Set("output.file.attempts", 1)
+	c.Set("output.file.path", path.Join(os.TempDir(), "go-audit.test.log"))
+	c.Set("output.file.mode", 0644)
+	c.Set("output.file.user", u.Username)
+	c.Set("output.file.group", g.Name)
+	w, err = newFileWriter(c)
+	assert.Nil(t, err)
+	assert.NotNil(t, w)
+	assert.IsType(t, &os.File{}, w.w)
+}
+
+func Test_fileRotation(t *testing.T) {
+	uid = os.Getuid()
+	gid = os.Getgid()
+	u, _ = user.LookupId(strconv.Itoa(uid))
+	g, _ = user.LookupGroupId(strconv.Itoa(gid))
+
+	// travis-ci is silly
+	if u.Username == "" {
+		u.Username = g.Name
+	}
+
+	// File rotation
+	os.Rename(path.Join(os.TempDir(), "go-audit.test.log"), path.Join(os.TempDir(), "go-audit.test.log.rotated"))
+	_, err = os.Stat(path.Join(os.TempDir(), "go-audit.test.log"))
+	assert.True(t, os.IsNotExist(err))
+	syscall.Kill(syscall.Getpid(), syscall.SIGUSR1)
+	time.Sleep(100 * time.Millisecond)
+	_, err = os.Stat(path.Join(os.TempDir(), "go-audit.test.log"))
+	assert.Nil(t, err)
+}

--- a/pkg/output/stdout_writer.go
+++ b/pkg/output/stdout_writer.go
@@ -1,0 +1,25 @@
+package output
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/slackhq/go-audit/pkg/slog"
+	"github.com/spf13/viper"
+)
+
+func init() {
+	register("stdout", newStdOutWriter)
+}
+
+func newStdOutWriter(config *viper.Viper) (*AuditWriter, error) {
+	attempts := config.GetInt("output.stdout.attempts")
+	if attempts < 1 {
+		return nil, fmt.Errorf("Output attempts for stdout must be at least 1, %v provided", attempts)
+	}
+
+	// info logger is no longer stdout
+	slog.Info.SetOutput(os.Stderr)
+
+	return NewAuditWriter(os.Stdout, attempts), nil
+}

--- a/pkg/output/stdout_writer_test.go
+++ b/pkg/output/stdout_writer_test.go
@@ -1,0 +1,26 @@
+package output
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_newStdOutWriter(t *testing.T) {
+	// attempts error
+	c := viper.New()
+	c.Set("output.stdout.attempts", 0)
+	w, err := newStdOutWriter(c)
+	assert.EqualError(t, err, "Output attempts for stdout must be at least 1, 0 provided")
+	assert.Nil(t, w)
+
+	// All good
+	c = viper.New()
+	c.Set("output.stdout.attempts", 1)
+	w, err = newStdOutWriter(c)
+	assert.Nil(t, err)
+	assert.NotNil(t, w)
+	assert.IsType(t, &os.File{}, w.w)
+}

--- a/pkg/output/syslog_writer.go
+++ b/pkg/output/syslog_writer.go
@@ -1,0 +1,61 @@
+package output
+
+import (
+	"fmt"
+	"log/syslog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/slackhq/go-audit/pkg/slog"
+	"github.com/spf13/viper"
+)
+
+func init() {
+	register("syslog", newSyslogWriter)
+}
+
+func newSyslogWriter(config *viper.Viper) (*AuditWriter, error) {
+	attempts := config.GetInt("output.syslog.attempts")
+	if attempts < 1 {
+		return nil, fmt.Errorf("Output attempts for syslog must be at least 1, %v provided", attempts)
+	}
+
+	syslogWriter, err := syslog.Dial(
+		config.GetString("output.syslog.network"),
+		config.GetString("output.syslog.address"),
+		syslog.Priority(config.GetInt("output.syslog.priority")),
+		config.GetString("output.syslog.tag"),
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("Failed to open syslog writer. Error: %v", err)
+	}
+
+	writer := NewAuditWriter(syslogWriter, attempts)
+	go handleLogRotation(config, writer)
+	return writer, nil
+}
+
+func handleLogRotation(config *viper.Viper, writer *AuditWriter) {
+	// Re-open our log file. This is triggered by a USR1 signal and is meant to be used upon log rotation
+
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, syscall.SIGUSR1)
+
+	for range sigc {
+		newWriter, err := newSyslogWriter(config)
+		if err != nil {
+			slog.Error.Fatalln("Error re-opening log file. Exiting.")
+		}
+
+		oldFile := writer.w.(*os.File)
+		writer.w = newWriter.w
+		writer.e = newWriter.e
+
+		err = oldFile.Close()
+		if err != nil {
+			slog.Error.Printf("Error closing old log file: %+v\n", err)
+		}
+	}
+}

--- a/pkg/output/syslog_writer_test.go
+++ b/pkg/output/syslog_writer_test.go
@@ -1,0 +1,44 @@
+package output
+
+import (
+	"log/syslog"
+	"net"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_newSyslogWriter(t *testing.T) {
+	// attempts error
+	c := viper.New()
+	c.Set("output.syslog.attempts", 0)
+	w, err := newSyslogWriter(c)
+	assert.EqualError(t, err, "Output attempts for syslog must be at least 1, 0 provided")
+	assert.Nil(t, w)
+
+	// dial error
+	c = viper.New()
+	c.Set("output.syslog.attempts", 1)
+	c.Set("output.syslog.priority", -1)
+	w, err = newSyslogWriter(c)
+	assert.EqualError(t, err, "Failed to open syslog writer. Error: log/syslog: invalid priority")
+	assert.Nil(t, w)
+
+	// All good
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer l.Close()
+
+	c = viper.New()
+	c.Set("output.syslog.attempts", 1)
+	c.Set("output.syslog.network", "tcp")
+	c.Set("output.syslog.address", l.Addr().String())
+	w, err = newSyslogWriter(c)
+	assert.Nil(t, err)
+	assert.NotNil(t, w)
+	assert.IsType(t, &syslog.Writer{}, w.w)
+}

--- a/pkg/output/writer.go
+++ b/pkg/output/writer.go
@@ -1,9 +1,12 @@
-package main
+package output
 
 import (
 	"encoding/json"
 	"io"
 	"time"
+
+	"github.com/slackhq/go-audit/pkg/parser"
+	"github.com/slackhq/go-audit/pkg/slog"
 )
 
 type AuditWriter struct {
@@ -20,7 +23,7 @@ func NewAuditWriter(w io.Writer, attempts int) *AuditWriter {
 	}
 }
 
-func (a *AuditWriter) Write(msg *AuditMessageGroup) (err error) {
+func (a *AuditWriter) Write(msg *parser.AuditMessageGroup) (err error) {
 	for i := 0; i < a.attempts; i++ {
 		err = a.e.Encode(msg)
 		if err == nil {
@@ -30,7 +33,7 @@ func (a *AuditWriter) Write(msg *AuditMessageGroup) (err error) {
 		if i != a.attempts {
 			// We have to reset the encoder because write errors are kept internally and can not be retried
 			a.e = json.NewEncoder(a.w)
-			el.Println("Failed to write message, retrying in 1 second. Error:", err)
+			slog.Error.Println("Failed to write message, retrying in 1 second. Error:", err)
 			time.Sleep(time.Second * 1)
 		}
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1,4 +1,4 @@
-package main
+package parser
 
 import (
 	"bytes"

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1,10 +1,11 @@
-package main
+package parser
 
 import (
-	"github.com/stretchr/testify/assert"
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAuditConstants(t *testing.T) {

--- a/pkg/slog/factory.go
+++ b/pkg/slog/factory.go
@@ -1,0 +1,19 @@
+package slog
+
+import (
+	"log"
+	"os"
+)
+
+var Info *log.Logger
+var Error *log.Logger
+
+func init() {
+	Info = log.New(os.Stdout, "", 0)
+	Error = log.New(os.Stderr, "", 0)
+}
+
+func Configure(flags int) {
+	Info.SetFlags(flags)
+	Error.SetFlags(flags)
+}


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
* [ ] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
In this PR I am proposing a bit of a refactor. Originally I was trying to just create a plug and play output system. Since all the output creation code was in audit.go it made it harder to create new output plugins. In this refactor to keep the code working the way it was before I had to create some packages of the existing parser code. The refactors besides the output package are only to facilitate the refactor.

The proposed plugin system for output works as a factory. You self register your output audit writer class using the factory, when you want an audit writer you use the factory method to create it using names for the output audit writer type.

I assume this is too big of a refactor to accept into the code base, it also does not follow one of the prime directives above (not refactoring too much). I thought I would share my coding even if it does not get pulled back into the upstream.

#### Test strategy

I have refactored and split up the unit tests that the output code was exercised by and added new tests for the output factory. I have compared the output of the benchmarks from `go bench` and also ran the modified code base on a machine and found parity between auditd, the original go-auditd and the modified go-auditd.
