### PR TITLE
Fix moved fsnotify dependency

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -255,8 +255,8 @@
 			"revisionTime": "2016-08-30T13:53:28Z"
 		},
 		{
-			"checksumSHA1": "93uHIq25lffEKY47PV8dBPD+XuQ=",
-			"path": "gopkg.in/fsnotify.v1",
+			"checksumSHA1": "gFpLQBd/1fdOJ3u4lSm5hiceceU=",
+			"path": "gopkg.in/fsnotify/fsnotify.v1",
 			"revision": "a8a77c9133d2d6fd8334f3260d06f60e8d80a5fb",
 			"revisionTime": "2016-06-29T01:11:04Z"
 		},


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary

The fsnotify package was moved from https://github.com/go-fsnotify/fsnotify to https://github.com/fsnotify/fsnotify

#### Related Issues

It should fix issue https://github.com/slackhq/go-audit/issues/24

#### Test strategy


