### PR TITLE
allow empty syscall filter entry

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -296,10 +296,6 @@ func createFilters(config *viper.Viper) ([]AuditFilter, error) {
 			return filters, fmt.Errorf("Filter %d is missing the `regex` entry", i+1)
 		}
 
-		if af.syscall == "" {
-			return filters, fmt.Errorf("Filter %d is missing the `syscall` entry", i+1)
-		}
-
 		if af.messageType == 0 {
 			return filters, fmt.Errorf("Filter %d is missing the `message_type` entry", i+1)
 		}

--- a/audit_test.go
+++ b/audit_test.go
@@ -417,15 +417,6 @@ func Test_createFilters(t *testing.T) {
 	assert.EqualError(t, err, "Filter 1 is missing the `message_type` entry")
 	assert.Empty(t, f)
 
-	// Missing message_type
-	c = viper.New()
-	rf = make([]interface{}, 0)
-	rf = append(rf, map[interface{}]interface{}{"message_type": "1", "regex": "1"})
-	c.Set("filters", rf)
-	f, err = createFilters(c)
-	assert.EqualError(t, err, "Filter 1 is missing the `syscall` entry")
-	assert.Empty(t, f)
-
 	// Good with strings
 	c = viper.New()
 	rf = make([]interface{}, 0)


### PR DESCRIPTION
* [X] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
* [X] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [X] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [X] I've written tests to cover the new code and functionality included in this PR.
* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary

Allow empty syscall definition for filtering audit entries

#### Related Issues

Fixes #13 and #50

#### Test strategy

This actually removed a superfluous test.

This has been tested in production.