### PR TITLE
Use latest 1.x version of go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: go
 
 go:
-  - 1.7.x
-  - 1.8.x
-  - 1.9.x
-  - tip
+  - 1.x
 
 install:
   - go get github.com/kardianos/govendor


### PR DESCRIPTION
Older versions of go will break with the syslog output test. This will test against the latest 1 dot minor release.