### PR TITLE
Support GELF logging driver as an output option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ go-audit.yaml
 *.deb
 *.out
 node_modules
+vendor/**
+!vendor/vendor.json

--- a/go-audit.yaml.example
+++ b/go-audit.yaml.example
@@ -73,6 +73,31 @@ output:
     user: root
     group: root
 
+  # Writes logs to Graylog2 server using GELF standard: http://docs.graylog.org/en/stable/pages/gelf.html
+  gelf:
+    enabled: false
+    attempts: 3
+
+    # Configure the type of socket this should be, this can only be "udp" or "tcp".
+    # Default value is "udp".
+    network: udp
+
+    # Set the remote address to connect to, this can be an IP address or a hostname and port.
+    # This setting is mandatory and has no default value.
+    address: localhost:12201
+
+    # Defines the compression settings when using GELF over UDP network
+    compression:
+      # Sets the level of compression
+      # This maps to `compress/flate` consts: https://godoc.org/compress/flate#pkg-constants
+      # Default value is: 1, which means "BestSpeed"
+      level: 1
+
+      # Configure the compression type the writer should use when sending messages to server
+      # This maps to `CompressionType` into gelf library: https://godoc.org/gopkg.in/Graylog2/go-gelf.v2/gelf#CompressType
+      # Default values is: 0, which means "Gzip"
+      type: 0
+
 # Configure logging, only stdout and stderr are used.
 log:
   # Gives you a bit of control over log line prefixes. Default is 0 - nothing.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -213,7 +213,7 @@
 			"revisionTime": "2016-05-18T18:29:53Z"
 		},
 		{
-			"checksumSHA1": "8fD/im5Kwvy3JgmxulDTambmE8w=",
+			"checksumSHA1": "Q4W6H1AocwvqFV/MNxSPsO1StcU=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "30de6d19a3bd89a5f38ae4028e23aaa5582648af",
 			"revisionTime": "2016-09-07T05:59:14Z"
@@ -243,16 +243,22 @@
 			"revisionTime": "2016-08-30T13:53:28Z"
 		},
 		{
-			"checksumSHA1": "n94g6qdzv0fgQFGelH4/HXOthl0=",
+			"checksumSHA1": "YW8pmJQwlwnsZiOwXp9JlDYr6l0=",
 			"path": "golang.org/x/text/unicode/cldr",
 			"revision": "f6f58eac0a9f37bcb49f8c8010c24cd382bf862d",
 			"revisionTime": "2016-08-30T13:53:28Z"
 		},
 		{
-			"checksumSHA1": "Aj3JSVO324FCjEAGm4ZwmC79bbo=",
+			"checksumSHA1": "aihk1EHGiDFDRDZuRf5CWqWpcYs=",
 			"path": "golang.org/x/text/unicode/norm",
 			"revision": "f6f58eac0a9f37bcb49f8c8010c24cd382bf862d",
 			"revisionTime": "2016-08-30T13:53:28Z"
+		},
+		{
+			"checksumSHA1": "vRPZRox/4JiAmGyEkW9ZNSsKmEc=",
+			"path": "gopkg.in/Graylog2/go-gelf.v2/gelf",
+			"revision": "4dbb9d7213480a8484c02610e3f51ecd9c506a71",
+			"revisionTime": "2018-03-26T13:34:23Z"
 		},
 		{
 			"checksumSHA1": "93uHIq25lffEKY47PV8dBPD+XuQ=",


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
This PR adds GELF logging driver as output option. It provides several features that a simple Syslog message does not. As well as others output the most settings of GELF can be handled on go-audit configuration file.

#### Test strategy
I ran a fresh Graylog2 stack using docker-compose (see more details at [1]) and added an input UDP on 12201 port. So, I pointed my GELF output into `go-audit.yaml` to my local Graylog2 server and it works. :+1: 

My `docker-compose.yaml` file is:

```
version: '2'
services:
  mongo:
    image: mongo:3

  elasticsearch:
    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.12
    environment:
      - http.host=0.0.0.0
      - xpack.security.enabled=false
      - "ES_JAVA_OPTS=-Xms2048m -Xmx2048m"
    ulimits:
      memlock:
        soft: -1
        hard: -1
    mem_limit: 2g

  graylog:
    image: graylog/graylog:3.0
    environment:
      - GRAYLOG_PASSWORD_SECRET=somepasswordpepper
      # Password: admin
      - GRAYLOG_ROOT_PASSWORD_SHA2=8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
      - GRAYLOG_HTTP_EXTERNAL_URI=http://127.0.0.1:9000/
    links:
      - mongo
      - elasticsearch
    ports:
      - 9000:9000
      - 12201:12201
      - 12201:12201/udp
``` 

My `go-audit.yaml` configuration file is:

```
socket_buffer:
  receive: 16384

events:
  min: 1300
  max: 1399

message_tracking:
  enabled: true
  log_out_of_order: false
  max_out_of_order: 500

output:
  gelf:
    enabled: true
    attempts: 3
    network: udp
    address: localhost:12201
    compression:
      level: 0
      type: 3 # Disable compression

log:
  flags: 0

rules:
  - -a exit,always -F arch=b64 -S execve
  - -a exit,always -F arch=b32 -S execve
  - -e 1

filters:
  - syscall: 49
    message_type: 1306
    regex: saddr=(10..|0A..)
```

Using `tcpdump` to intecept a single message

```
$ sudo tcpdump -A -v -i lo dst port 12201
23:19:19.721368 IP6 (flowlabel 0x41977, hlim 64, next-header UDP (17) payload length: 454) localhost.59298 > localhost.12201: [bad udp cksum 0x01d9 -> 0x7a7e!] UDP, length 446
`..w...@................................../.....{"version":"1.1","host":"poseidon.olympus","short_message":"{\"sequence\":152379,\"timestamp\":\"1542503954.719\",\"messages\":[{\"type\":1305,\"data\":\"audit_pid=12141 old=12141 auid=1000 ses=3 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 res=0\"}],\"uid_map\":{\"1000\":\"nettoclaudio\"}}","timestamp":1542503959,"level":6,"facility":"go-audit","_file":"/home/nettoclaudio/.local/apps/go/src/encoding/json/stream.go","_line":225}
```

![Message indexed on Graylog2 server](https://user-images.githubusercontent.com/7503687/48667602-3a26a900-eac1-11e8-902b-3c09a6521d93.png)

[1] https://github.com/Graylog2/graylog-docker
