### PR TITLE
Fixed race conditions for log writing and minor bugs in parser.go

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -208,13 +208,10 @@ func handleLogRotation(config *viper.Viper, writer *AuditWriter) {
 			el.Fatalln("Error re-opening log file. Exiting.")
 		}
 
-		oldFile := writer.w.(*os.File)
-		writer.w = newWriter.w
-		writer.e = newWriter.e
+		err = writer.rotate(newWriter)
 
-		err = oldFile.Close()
 		if err != nil {
-			el.Printf("Error closing old log file: %+v\n", err)
+			el.Println(err)
 		}
 	}
 }

--- a/audit_test.go
+++ b/audit_test.go
@@ -156,7 +156,8 @@ func Test_createFileOutput(t *testing.T) {
 	// chown error
 	c = viper.New()
 	c.Set("output.file.attempts", 1)
-	c.Set("output.file.path", path.Join(os.TempDir(), "go-audit.test.log"))
+	testLogFile := path.Join(os.TempDir(), "go-audit.test.log")
+	c.Set("output.file.path", testLogFile)
 	c.Set("output.file.mode", 0644)
 	c.Set("output.file.user", "root")
 	c.Set("output.file.group", "root")
@@ -315,8 +316,10 @@ func Test_createOutput(t *testing.T) {
 	w, err = createOutput(c)
 	assert.Nil(t, err)
 	assert.NotNil(t, w)
+	w.mutex.Lock()
 	assert.IsType(t, &AuditWriter{}, w)
 	assert.IsType(t, &os.File{}, w.w)
+	w.mutex.Unlock()
 
 	// File rotation
 	os.Rename(path.Join(os.TempDir(), "go-audit.test.log"), path.Join(os.TempDir(), "go-audit.test.log.rotated"))

--- a/client_test.go
+++ b/client_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"bytes"
 	"encoding/binary"
-	"github.com/stretchr/testify/assert"
 	"os"
+	"sync/atomic"
 	"syscall"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNetlinkClient_KeepConnection(t *testing.T) {
@@ -99,7 +101,7 @@ func TestNewNetlinkClient(t *testing.T) {
 	} else {
 		assert.True(t, (n.fd > 0), "No file descriptor")
 		assert.True(t, (n.address != nil), "Address was nil")
-		assert.Equal(t, uint32(0), n.seq, "Seq should start at 0")
+		assert.Equal(t, uint32(0), atomic.LoadUint32(&n.seq), "Seq should start at 0")
 		assert.True(t, MAX_AUDIT_MESSAGE_LENGTH >= len(n.buf), "Client buffer is too small")
 
 		assert.Equal(t, "Socket receive buffer size: ", lb.String()[:28], "Expected some nice log lines")

--- a/parser.go
+++ b/parser.go
@@ -89,7 +89,7 @@ func (amg *AuditMessageGroup) AddMessage(am *AuditMessage) {
 	amg.Msgs = append(amg.Msgs, am)
 	//TODO: need to find more message types that won't contain uids, also make these constants
 	switch am.Type {
-	case 1309, 1307, 1306:
+	case 1309, 1307, 1306, 1305:
 		// Don't map uids here
 	case 1300:
 		amg.findSyscall(am)

--- a/parser.go
+++ b/parser.go
@@ -126,7 +126,7 @@ func (amg *AuditMessageGroup) mapUids(am *AuditMessage) {
 
 		// Don't bother re-adding if the existing group already has the mapping
 		if _, ok := amg.UidMap[uid]; !ok {
-			amg.UidMap[uid] = getUsername(data[start : start+end])
+			amg.UidMap[uid] = getUsername(uid)
 		}
 
 		// Find the next uid= if we have space for one

--- a/parser.go
+++ b/parser.go
@@ -33,7 +33,7 @@ type AuditMessageGroup struct {
 	CompleteAfter time.Time         `json:"-"`
 	Msgs          []*AuditMessage   `json:"messages"`
 	UidMap        map[string]string `json:"uid_map"`
-	Syscall       string            `json:"-"`
+	Syscall       string            `json:"syscall"`
 }
 
 // Creates a new message group from the details parsed from the message


### PR DESCRIPTION
* [X] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
* [X] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [X] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [X] I've written tests to cover the new code and functionality included in this PR.
* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
* Added a mutex to AuditWriter in order to avoid a race condition.
* Added a function `rotate` to use the mutex to rotate logs.
* Modified tests accordingly to the previous changes and used an atomic.LoadUint32 for n.seq.

* Added the `syscall` JSON parameter in order for it to appear in AuditMessageGroup.
* Added 1305 to the `AddMessage` switch in order to not map the uid for that message.  

#### Related Issues
None

#### Test strategy
Modified the tests in order to work with the mutex changes. Tested in a test environment to verify the 'syscall' parameter was appearing in the JSON struct.
