### PR TITLE
Add ability to skip applying rules

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -47,6 +47,7 @@ func loadConfig(configFile string) (*viper.Viper, error) {
 	config.SetDefault("output.gelf.compression.level", int(flate.BestSpeed))
 	config.SetDefault("output.gelf.compression.type", int(gelf.CompressGzip))
 	config.SetDefault("log.flags", 0)
+	config.SetDefault("skip_rules", false)
 
 	if err := config.ReadInConfig(); err != nil {
 		return nil, err
@@ -378,8 +379,10 @@ func main() {
 		el.Fatal(err)
 	}
 
-	if err := setRules(config, lExec); err != nil {
-		el.Fatal(err)
+	if !config.GetBool("skip_rules") {
+		if err := setRules(config, lExec); err != nil {
+			el.Fatal(err)
+		}
 	}
 
 	filters, err := createFilters(config)


### PR DESCRIPTION
* [ ] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
* [ ] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [ ] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [ ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary

This introduces a `skip_rules` configuration setting which prevents go-audit from setting rules itself. This enables audit rules to be set by an external system, utilizing go-audit exclusively for logging.
