### PR TITLE
only append the ExtraParser if it's non-nill

### DIFF
--- a/extras.go
+++ b/extras.go
@@ -21,7 +21,9 @@ func createExtraParsers(config *viper.Viper) ExtraParsers {
 		if err != nil {
 			el.Fatalf("Failed to create ExtraParser: %v", err)
 		}
-		extraParsers = append(extraParsers, cp)
+		if cp != nil {
+			extraParsers = append(extraParsers, cp)
+		}
 	}
 	return extraParsers
 }


### PR DESCRIPTION
the ExtraParser constructor returns nil if the parser is not enabled, so don't append
it if it is nil.

Fixes #69 