### PR TITLE
build and release process

### DIFF
--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -1,0 +1,30 @@
+name: gofmt
+on:
+  push:
+  pull_request:
+    paths:
+      - '.github/workflows/gofmt.yml'
+      - '**.go'
+jobs:
+
+  gofmt:
+    name: Run gofmt
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.14
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.14
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
+    - name: gofmt
+      run: |
+        if [ "$(find . -iname '*.go' | xargs gofmt -l)" ]
+        then
+          find . -iname '*.go' | xargs gofmt -d
+          exit 1
+        fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]*'
+
+name: Create release and upload binaries
+
+jobs:
+  build-linux:
+    name: Create and Upload Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.14
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build
+        run: |
+          make BUILD_NUMBER="${GITHUB_REF#refs/tags/v}" release
+
+      - name: Create sha256sum
+        run: |
+          for dir in build
+          do
+            (
+              cd $dir
+              for v in *.tar.gz
+              do
+                sha256sum $v
+                tar zxf $v --to-command='sh -c "sha256sum | sed s=-$='$v'/$TAR_FILENAME="'
+              done
+            )
+          done | sort -k 2 >SHASUM256.txt
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      ##
+      ## Upload assets (I wish we could just upload the whole folder at once...
+      ##
+
+      - name: Upload SHASUM256.txt
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./SHASUM256.txt
+          asset_name: SHASUM256.txt
+          asset_content_type: text/plain
+
+      - name: Upload linux-amd64
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./build/go-audit-linux-amd64.tar.gz
+          asset_name: go-audit-linux-amd64.tar.gz
+          asset_content_type: application/gzip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Build and test
+on:
+  push:
+  pull_request:
+    paths:
+      - '.github/workflows/test.yml'
+      - '**Makefile'
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+jobs:
+
+  test-linux:
+    name: Build all and test
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Set up Go 1.14
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Build
+        run: make
+
+      - name: Test
+        run: make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- You can now run `go-audit -version` to check the build version.
+
+[Unreleased]: https://github.com/slackhq/go-audit/compare/75218d0...HEAD

--- a/audit.go
+++ b/audit.go
@@ -20,6 +20,13 @@ import (
 	"gopkg.in/Graylog2/go-gelf.v2/gelf"
 )
 
+// A version string that can be set with
+//
+//     -ldflags "-X main.Build=SOMEVERSION"
+//
+// at compile-time.
+var Build string
+
 var l = log.New(os.Stdout, "", 0)
 var el = log.New(os.Stderr, "", 0)
 
@@ -358,8 +365,14 @@ func createFilters(config *viper.Viper) ([]AuditFilter, error) {
 
 func main() {
 	configFile := flag.String("config", "", "Config file location")
+	printVersion := flag.Bool("version", false, "Print version")
 
 	flag.Parse()
+
+	if *printVersion {
+		fmt.Printf("Version: %s\n", Build)
+		os.Exit(0)
+	}
 
 	if *configFile == "" {
 		el.Println("A config file must be provided")

--- a/client.go
+++ b/client.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"syscall"
 	"time"
-	"fmt"
 )
 
 // Endianness is an alias for what we assume is the current machine endianness

--- a/extras_containers.go
+++ b/extras_containers.go
@@ -1,3 +1,4 @@
+// +build amd64
 // +build !nocontainers
 
 package main


### PR DESCRIPTION
#### PR Summary

This change adds a build and release process for go-audit. go-fmt and
tests are run with every commit, and a special release workflow runs
when a version tag is pushed to the repo. This is based on the build process for https://github.com/slackhq/nebula. We currently only build binaries for amd64, but we can easily build for other architectures if there is demand. This also sets up a CHANGELOG
file that we will update with the first tagged release.

#### Related Issues

Fixes #77 (once a version is tagged after this has been merged).

#### Test strategy

I tested this on my fork: https://github.com/wadey/go-audit/releases