### PR TITLE
remove govendor from installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ I became interested in creating a replacement for the existing daemon.
 
 ##### Installation
 
-1. Install [golang](https://golang.org/doc/install), version 1.7 or greater is required
+1. Install [golang](https://golang.org/doc/install), version 1.14 or greater is required
 2. Clone the repo
 
     ```

--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ I became interested in creating a replacement for the existing daemon.
 ##### Installation
 
 1. Install [golang](https://golang.org/doc/install), version 1.7 or greater is required
-2. Install [`govendor`](https://github.com/kardianos/govendor) if you haven't already
-
-    ```go get -u github.com/kardianos/govendor```
-    
 2. Clone the repo
 
     ```
@@ -34,13 +30,13 @@ I became interested in creating a replacement for the existing daemon.
     cd go-audit
     ```
     
-2. Build the binary
+3. Build the binary
 
     ```
     make
     ```
 
-3. Copy the binary `go-audit` to wherever you'd like
+4. Copy the binary `go-audit` to wherever you'd like
 
 ##### Testing
 


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary

> `govendor` is not required after the switch to go modules

#### Related Issues

> https://github.com/slackhq/go-audit/commit/e90a1ca903c1fb81c0d89da6884eb3a5f16141ec

#### Test strategy

> this is just a doco update
