### PR TITLE
Optional user-supplied key/value pairs in output

### DIFF
--- a/extras_metadata.go
+++ b/extras_metadata.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"github.com/spf13/viper"
+)
+
+func init() {
+	RegisterExtraParser(func(config *viper.Viper) (ExtraParser, error) {
+		if config.GetBool("extras.metadata.enabled") {
+			mp := NewMetadataParser(config)
+			return mp, nil
+		}
+		return nil, nil
+	})
+}
+
+type MetadataParser struct {
+	pairs map[string]string
+}
+
+func NewMetadataParser(config *viper.Viper) *MetadataParser {
+	return &MetadataParser{
+		pairs: config.GetStringMapString("extras.metadata.pairs"),
+	}
+}
+
+func (mp MetadataParser) Parse(am *AuditMessage) {
+	am.Metadata = mp.pairs
+}

--- a/extras_metadata_test.go
+++ b/extras_metadata_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetadataParser(t *testing.T) {
+	pairs := map[string]string{"hello": "world"}
+
+	c := viper.New()
+	c.Set("extras.metadata.enabled", true)
+	c.Set("extras.metadata.pairs", pairs)
+
+	am := &AuditMessage{}
+
+	mp := NewMetadataParser(c)
+	mp.Parse(am)
+
+	assert.Equal(t, am.Metadata, pairs)
+}

--- a/go-audit.yaml.example
+++ b/go-audit.yaml.example
@@ -150,3 +150,11 @@ extras:
     pid_cache: 0
     # number of container_id -> docker_details to cache (0 means disable cache)
     docker_cache: 0
+
+  # Add arbitrary key/value pairs to all messages. This capability could be
+  # used to pass additional context about the running environment.
+  metadata:
+    enabled: false
+    pairs:
+      environment: prod
+      region: us-east-2

--- a/parser.go
+++ b/parser.go
@@ -27,6 +27,7 @@ type AuditMessage struct {
 	AuditTime string `json:"-"`
 
 	Containers map[string]string `json:"containers,omitempty"`
+	Metadata   map[string]string `json:"metadata,omitempty"`
 }
 
 type AuditMessageGroup struct {


### PR DESCRIPTION
The user / configuration management system can add additional key/value
pairs which can add useful contextual information to the JSON records
produced.

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary

Adds the ability to add arbitrary key/value pairs to every output record. This capability can add extra contextual information that may be useful for systems processing and classifying audit records.

#### Related Issues

N/A

#### Test strategy

Basic test added.
