### PR TITLE
Cgroup extras.

### DIFF
--- a/extras_cgroups.go
+++ b/extras_cgroups.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"github.com/spf13/viper"
+)
+
+func init() {
+	RegisterExtraParser(func(config *viper.Viper) (ExtraParser, error) {
+		if config.GetBool("extras.cgroups.enabled") {
+			return &CgroupParser{}, nil
+		}
+		return nil, nil
+	})
+}
+
+type CgroupParser struct {
+}
+
+func (p *CgroupParser) Parse(am *AuditMessage) {
+	switch am.Type {
+	case 1300, 1326: // AUDIT_SYSCALL, AUDIT_SECCOMP
+		pid, _ := getPid(am.Data)
+		am.CgroupRoot = p.getCgroupRootForPid(pid)
+	}
+}
+
+func (p *CgroupParser) getCgroupRootForPid(pid int) string {
+	if pid == 0 {
+		return ""
+	}
+
+	var v1PidPath string
+	cgroups, err := taskControlGroups(pid, pid)
+	if err != nil {
+		return ""
+	}
+
+	for _, cgroup := range cgroups {
+		if cgroup.ID == 0 {
+			// v2 path
+			return cgroup.Path
+		} else if len(cgroup.Controllers) > 0 && cgroup.Controllers[0] == "pids" {
+			// fall back to cgroup v1 pid path if we don't have cgroups v2
+			v1PidPath = cgroup.Path
+		}
+	}
+
+	return v1PidPath
+}

--- a/extras_cgroups.go
+++ b/extras_cgroups.go
@@ -7,6 +7,7 @@ import (
 func init() {
 	RegisterExtraParser(func(config *viper.Viper) (ExtraParser, error) {
 		if config.GetBool("extras.cgroups.enabled") {
+			l.Printf("cgroup parser enabled")
 			return &CgroupParser{}, nil
 		}
 		return nil, nil
@@ -20,7 +21,7 @@ func (p *CgroupParser) Parse(am *AuditMessage) {
 	switch am.Type {
 	case 1300, 1326: // AUDIT_SYSCALL, AUDIT_SECCOMP
 		pid, _ := getPid(am.Data)
-		am.CgroupRoot = p.getCgroupRootForPid(pid)
+		am.Extras.CgroupRoot = p.getCgroupRootForPid(pid)
 	}
 }
 

--- a/extras_cgroups.go
+++ b/extras_cgroups.go
@@ -19,9 +19,12 @@ type CgroupParser struct {
 
 func (p *CgroupParser) Parse(am *AuditMessage) {
 	switch am.Type {
-	case 1300, 1326: // AUDIT_SYSCALL, AUDIT_SECCOMP
+	case 1300, 1302, 1309, 1326: // AUDIT_SYSCALL, AUDIT_PATH, AUDIT_EXECVE, AUDIT_SECCOMP
 		pid, _ := getPid(am.Data)
-		am.Extras.CgroupRoot = p.getCgroupRootForPid(pid)
+		cgroup := p.getCgroupRootForPid(pid)
+		if cgroup != "" {
+			am.Extras = &AuditExtras{CgroupRoot: cgroup}
+		}
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -27,7 +27,9 @@ type AuditMessage struct {
 	AuditTime string `json:"-"`
 
 	Containers map[string]string `json:"containers,omitempty"`
-	CgroupRoot string            `json:"cgroup_root,omitempty"`
+	Extras     struct {
+		CgroupRoot string `json:"cgroup_root,omitempty"`
+	} `json:"extras,omitempty"`
 }
 
 type AuditMessageGroup struct {

--- a/parser.go
+++ b/parser.go
@@ -27,6 +27,7 @@ type AuditMessage struct {
 	AuditTime string `json:"-"`
 
 	Containers map[string]string `json:"containers,omitempty"`
+	CgroupRoot string            `json:"cgroup_root,omitempty"`
 }
 
 type AuditMessageGroup struct {

--- a/parser.go
+++ b/parser.go
@@ -27,9 +27,11 @@ type AuditMessage struct {
 	AuditTime string `json:"-"`
 
 	Containers map[string]string `json:"containers,omitempty"`
-	Extras     struct {
-		CgroupRoot string `json:"cgroup_root,omitempty"`
-	} `json:"extras,omitempty"`
+	Extras     *AuditExtras      `json:"extras,omitempty"`
+}
+
+type AuditExtras struct {
+	CgroupRoot string `json:"cgroup_root,omitempty"`
 }
 
 type AuditMessageGroup struct {


### PR DESCRIPTION
#### PR Summary

Add a new option `extras.cgroups.enabled` that when enabled will annotate events with the cgroup_v2 root path. 

The primary use-case for this is to be able to correlate related events that share the same cgroup path (such as child processes forked from a systemd unit).
