### PR TITLE
Move getPid to helpers file

### DIFF
--- a/extras_containers.go
+++ b/extras_containers.go
@@ -1,12 +1,10 @@
-// +build amd64
-// +build !nocontainers
+//go:build amd64 && !nocontainers
+// +build amd64,!nocontainers
 
 package main
 
 import (
 	"context"
-	"strconv"
-	"strings"
 
 	dockertypes "github.com/docker/docker/api/types"
 	dockerclient "github.com/docker/docker/client"
@@ -97,46 +95,6 @@ func (c ContainerParser) Parse(am *AuditMessage) {
 	switch am.Type {
 	case 1300, 1326:
 		am.Containers = c.getContainersForPid(getPid(am.Data))
-	}
-}
-
-func getPid(data string) (pid, ppid int) {
-	start := 0
-	end := 0
-	var err error
-
-	for {
-		if start = strings.Index(data, "pid="); start < 0 {
-			return
-		}
-
-		// Progress the start point beyon the = sign
-		start += 4
-		if end = strings.IndexByte(data[start:], spaceChar); end < 0 {
-			// There was no ending space, maybe the pid is at the end of the line
-			end = len(data) - start
-
-			// If the end of the line is greater than 7 characters away (overflows 22 bit uint) then it can't be a pid
-			// > On 64-bit systems, pid_max can be set to any value up to 2^22 (PID_MAX_LIMIT, approximately 4 million).
-			if end > 7 {
-				return
-			}
-		}
-
-		id := data[start : start+end]
-		if start > 4 && data[start-5] == 'p' {
-			ppid, err = strconv.Atoi(id)
-		} else {
-			pid, err = strconv.Atoi(id)
-		}
-		if err != nil {
-			el.Printf("Failed to parse pid: %s: %v\n", id, err)
-		}
-		if pid != 0 && ppid != 0 {
-			return
-		}
-
-		data = data[start+end:]
 	}
 }
 

--- a/extras_helpers.go
+++ b/extras_helpers.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+)
+
+func getPid(data string) (pid, ppid int) {
+	start := 0
+	end := 0
+	var err error
+
+	for {
+		if start = strings.Index(data, "pid="); start < 0 {
+			return
+		}
+
+		// Progress the start point beyon the = sign
+		start += 4
+		if end = strings.IndexByte(data[start:], spaceChar); end < 0 {
+			// There was no ending space, maybe the pid is at the end of the line
+			end = len(data) - start
+
+			// If the end of the line is greater than 7 characters away (overflows 22 bit uint) then it can't be a pid
+			// > On 64-bit systems, pid_max can be set to any value up to 2^22 (PID_MAX_LIMIT, approximately 4 million).
+			if end > 7 {
+				return
+			}
+		}
+
+		id := data[start : start+end]
+		if start > 4 && data[start-5] == 'p' {
+			ppid, err = strconv.Atoi(id)
+		} else {
+			pid, err = strconv.Atoi(id)
+		}
+		if err != nil {
+			el.Printf("Failed to parse pid: %s: %v\n", id, err)
+		}
+		if pid != 0 && ppid != 0 {
+			return
+		}
+
+		data = data[start+end:]
+	}
+}


### PR DESCRIPTION
The extras_containers.go file is only built on amd64. This prevents
the use of this function by the cgroup parser extension on non-amd64
architectures.

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary

Move getPid to helpers file.

The extras_containers.go file is only built on amd64. This prevents
the use of this function by the cgroup parser extension on non-amd64
architectures.

#### Related Issues

N/A

#### Test strategy

N/A
