### PR TITLE
update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,9 @@
-* [ ] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
-* [ ] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
-* [ ] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
-* [ ] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
+###  Summary
+
+Describe the goal of this PR. Mention any related Issue numbers.
+
+### Requirements (place an `x` in each `[ ]`)
+
+* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
+* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
 * [ ] I've written tests to cover the new code and functionality included in this PR.
-* [ ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).
-
-#### PR Summary
-
-> e.g. New functionality for producing whatsits.
-
-#### Related Issues
-
-> e.g. Fixes #206 and closes #230
-
-#### Test strategy
-
-> e.g. Add tests around whatsit production.


### PR DESCRIPTION
The current template has the wrong link for the CLA. We have other things
we need to update as well, but start with the easy one to fix.

Source from:

- https://github.com/slackhq/oss-guidelines/blob/main/PULL_REQUEST_TEMPLATE.md